### PR TITLE
fix: chart testing issue

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -18,7 +18,7 @@ runs:
         python-version: 3.7
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.4.0
+      uses: helm/chart-testing-action@cb49023b9227b1097e5eddd8824f48bdea11b1aa
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.5.0


### PR DESCRIPTION
Fixing chart testing issue we get when running CI:
https://github.com/coralogix/opentelemetry-helm-charts/actions/runs/6705872219/job/18221184068?pr=42

```
INFO: Downloading bootstrap version 'v2.0.0' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v2.0.0/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v2.0.0'
Error: Process completed with exit code 1.
```

The fix is to use current master -> https://github.com/helm/chart-testing-action/commit/cb49023b9227b1097e5eddd8824f48bdea11b1aa