### PR TITLE
Enable target allocator in non-CRD mode

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.77.5
+version: 0.77.6
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9ebc630777aefcb772f9e18c8360adaea46e9d5525100344889bca20be8ce073
+        checksum/config: 5456b8abd0baf972f8ee4becf21b14c3381e536f93511f84a06ef0c0081f286b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cdb693816a6806a62e1e1dbd4c2048c1550d355a5d64d19c178c9923947748d6
+        checksum/config: 26c7015f33d3731ad53cb89de961308fee6e35f78669f6e474943b213909950d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a7980f263f0eb7122a682db9fc07f90857d1fd894179f4e55f14bbbd3c0d1b3
+        checksum/config: c2afc93093b432ba0461b8d0ba9e6ddca57047e989c62eb526188910535eb9ad
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 083461eddc9d3ee98c01b677e231cc47d89338700eaff668cea3b43ddfc9e376
+        checksum/config: 2b103a2d2c7cd2c17e9d46ad1cced27dcf925c10a88453eab5b64d6b9e5c56cb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 083461eddc9d3ee98c01b677e231cc47d89338700eaff668cea3b43ddfc9e376
+        checksum/config: 2b103a2d2c7cd2c17e9d46ad1cced27dcf925c10a88453eab5b64d6b9e5c56cb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 66a5d4b537c814d43a4b392ca229ffe429a484e98656777144266f8f99db50d9
+        checksum/config: bec4b1965a7d29fcbb820c9735eb2fe01b6acf12be2e966050e0575f21f8e85d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
@@ -1,0 +1,44 @@
+---
+# Source: opentelemetry-collector/templates/clusterrole-targetallocator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-opentelemetry-collector-targetallocator
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources:
+    - nodes
+    - nodes/metrics
+    - services
+    - endpoints
+    - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+    - configmaps
+    verbs: ["get"]
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs: ["get", "list", watch"]
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - servicemonitors
+    - podmonitors
+    verbs:
+    - '*'

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
@@ -1,0 +1,20 @@
+---
+# Source: opentelemetry-collector/templates/clusterrolebinding-targetallocator.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-opentelemetry-collector-targetallocator
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-opentelemetry-collector-targetallocator
+subjects:
+- kind: ServiceAccount
+  name: example-opentelemetry-collector-targetallocator
+  namespace: default

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -1,0 +1,91 @@
+---
+# Source: opentelemetry-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-opentelemetry-collector-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  relay: |
+    exporters:
+      logging: {}
+    extensions:
+      health_check: {}
+      memory_ballast:
+        size_in_percentage: 40
+    processors:
+      batch: {}
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+        target_allocator:
+          collector_id: ${MY_POD_NAME}
+          endpoint: http://example-opentelemetry-collector-targetallocator
+          interval: 30s
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - memory_ballast
+      pipelines:
+        logs:
+          exporters:
+          - logging
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+        metrics:
+          exporters:
+          - logging
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - prometheus
+        traces:
+          exporters:
+          - logging
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - jaeger
+          - zipkin
+      telemetry:
+        metrics:
+          address: ${env:MY_POD_IP}:8888

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
@@ -1,0 +1,21 @@
+---
+# Source: opentelemetry-collector/templates/configmap-targetallocator.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-opentelemetry-collector-targetallocator
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  targetallocator.yaml: |
+    allocation_strategy: 
+    label_selector:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: example
+    prometheus_cr:
+      scrape_interval: 30s

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -1,0 +1,103 @@
+---
+# Source: opentelemetry-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: example-opentelemetry-collector-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 602d7003535efb82032368f61ff070545055944693a35cc2c6db7931cde5ff27
+        
+      labels:
+        app.kubernetes.io/name: opentelemetry-collector
+        app.kubernetes.io/instance: example
+        component: agent-collector
+        
+    spec:
+      
+      serviceAccountName: example-opentelemetry-collector
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-collector
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "otel/opentelemetry-collector-contrib:0.88.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-collector-configmap
+      priorityClassName: "example-opentelemetry-collector"
+      volumes:
+        - name: opentelemetry-collector-configmap
+          configMap:
+            name: example-opentelemetry-collector-agent
+            items:
+              - key: relay
+                path: relay.yaml
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: false

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 602d7003535efb82032368f61ff070545055944693a35cc2c6db7931cde5ff27
+        checksum/config: 930ace9c45ef65d90e995c9d29a690a39eac10bd1e5251bc14e96085ca03bc93
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4b3661cf20477e3c2d50f39a4fbb9de4aee51dc63d9347427aa05caa433a7892
+        checksum/config: 28372a60a6da2ff327b4b085e1317298ac69b9c0f5a90fff6254159e83bb3a43
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
@@ -1,0 +1,61 @@
+---
+# Source: opentelemetry-collector/templates/deployment-targetallocator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-opentelemetry-collector-targetallocator
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+      app.kubernetes.io/instance: example
+      component: agent-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 4b3661cf20477e3c2d50f39a4fbb9de4aee51dc63d9347427aa05caa433a7892
+        
+      labels:
+        app.kubernetes.io/name: opentelemetry-collector
+        app.kubernetes.io/instance: example
+        component: agent-collector
+        
+    spec:
+      containers:
+        - name: example-opentelemetry-collector-targetallocator
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.77.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --enable-prometheus-cr-watcher
+          env:
+          - name: OTELCOL_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          volumeMounts:
+          - mountPath: /conf
+            name: ta-internal
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: targetallocator.yaml
+            path: targetallocator.yaml
+          name: example-opentelemetry-collector-targetallocator
+        name: ta-internal
+      serviceAccountName: example-opentelemetry-collector-targetallocator

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/priorityclass.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/priorityclass.yaml
@@ -1,0 +1,9 @@
+---
+# Source: opentelemetry-collector/templates/priorityclass.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: example-opentelemetry-collector
+value: 1000
+globalDefault: false
+description: "This priority class should be used for OpenTelemetry collector pods."

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
@@ -1,0 +1,23 @@
+---
+# Source: opentelemetry-collector/templates/service-targetallocator.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-opentelemetry-collector-targetallocator
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm
+    component: agent-collector
+spec:
+  ports:
+  - name: targetallocation
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    component: agent-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
@@ -1,0 +1,12 @@
+---
+# Source: opentelemetry-collector/templates/serviceaccount-targetallocator.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-collector-targetallocator
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: opentelemetry-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-collector-0.77.5
+    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.88.0"
+    app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/values.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/values.yaml
@@ -1,0 +1,15 @@
+mode: daemonset
+
+targetAllocator:
+  enabled: true
+  prometheusCR:
+    enabled: true
+  image:
+    repository: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator"
+    pullPolicy: IfNotPresent
+    tag: "0.77.0"
+
+priorityClass:
+  create: true
+  name: ""
+  priorityValue: 1000

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5a4eb6ff5faa0452ebfcd141c7df30bce55beaad93358afbb3e68ab3af7b33f3
+        checksum/config: fee1a3b702263d6b4bee89da51e409d84b145b22d330ddd4c7f92f9d4cd6abf2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ee2c51c0c5525842a7c8be63ef631657011d74a0dd1990f760aa4696497076f7
+        checksum/config: 696f24adabb61344fe7f923a7ac495dc15ec58ea989a3955371b5d4c38f8bf6a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 291e8a35c8dbb173e490d45fe3c90159af22d88080be079485f85f057a2f7293
+        checksum/config: 79782c2c8c1b4a2c76f17fc0fb6039f20d93c1596fbed837deacab6040567f69
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 61d32b506e2d3c7d83007301ed6aeff0334b9f37c62d0be936eaddb609e038d1
+        checksum/config: e11e5f3b1c66e4148d9266275661be3433a0f5030dd881571fa185c18565fde1
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6d69627bb67f91da4ccf4a14d1f47f9bf870e6d2183905e1619bdc27cb4b0390
+        checksum/config: 970db0d9d1ce9686143b5b32a68acf0112d30fe8d37514c20d1bc610471a77c7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 492ff9de0d04b28a44be39f477d3c8956383a56e3217d2be6d66fea80f1aa995
+        checksum/config: b637c1c3ce852139cf0078c09c4e42f47c3e3bc7d7b0cd0aa92abf22fc4deac7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/opentelemetrycollector-values.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/opentelemetrycollector-values.yaml
@@ -1,13 +1,15 @@
 mode: statefulset
 collectorCRD:
   generate: true
-  targetAllocator:
+
+targetAllocator:
+  enabled: true
+  prometheusCR:
     enabled: true
-    prometheusCR:
-      enabled: true
-    image:
-      repository: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator"
-      tag: "0.77.0"
+  image:
+    repository: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator"
+    pullPolicy: IfNotPresent
+    tag: "0.77.0"
 
 presets:
   logsCollection:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
@@ -264,6 +264,10 @@ spec:
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888
+        target_allocator:
+          collector_id: ${MY_POD_NAME}
+          endpoint: http://example-opentelemetry-collector-targetallocator
+          interval: 30s
       receiver_creator/mysql:
         receivers:
           mysql:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: default-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b24905cb0757a5fb1bc0bcf95e821c3219c1b9909c941c30b61f3bfac770753d
+        checksum/config: 9dea405c07c9d3fdd146d1ae6daa578f948a43d07fe38e323fb7287c8e44f459
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b01f2c31afbe4f09b0e5b85bdebdd8d78c8423f057af79bbbba4eec3c4937f0
+        checksum/config: 07ce4cebb33eec00e0aa9386b4ecfdb0468de5bca1b4152c2310fd0cbfd8a6df
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.77.5
+    helm.sh/chart: opentelemetry-collector-0.77.6
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.88.0"

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -47,6 +47,12 @@ containers:
           fieldRef:
             apiVersion: v1
             fieldPath: status.podIP
+      {{- if .Values.targetAllocator.enabled }}
+      - name: MY_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      {{- end }}
       {{- if and .Values.presets.kubernetesAttributes.enabled (eq .Values.mode "daemonset") }}
       - name: K8S_NODE_NAME
         valueFrom:

--- a/charts/opentelemetry-collector/templates/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/clusterrole-targetallocator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.collectorCRD.targetAllocator.enabled -}}
+{{- if and (.Values.targetAllocator.enabled) (not (.Values.targetAllocator.serviceAccount)) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -30,7 +30,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
-  {{- if .Values.collectorCRD.targetAllocator.enabled }}
+  {{- if .Values.targetAllocator.prometheusCR.enabled }}
   - apiGroups:
     - monitoring.coreos.com
     resources:

--- a/charts/opentelemetry-collector/templates/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/clusterrolebinding-targetallocator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.collectorCRD.targetAllocator.enabled -}}
+{{- if and (.Values.targetAllocator.enabled) (not (.Values.targetAllocator.serviceAccount)) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/opentelemetry-collector/templates/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/configmap-targetallocator.yaml
@@ -1,0 +1,27 @@
+{{- if not .Values.collectorCRD.generate -}}
+{{- if .Values.targetAllocator.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  labels:
+    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+data:
+  targetallocator.yaml: |
+    allocation_strategy: {{ .Values.targetAllocator.allocationStrategy }}
+    label_selector:
+      app.kubernetes.io/name: {{ include "opentelemetry-collector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+    prometheus_cr:
+      scrape_interval: 30s
+    {{- if .Values.targetAllocator.podMonitorSelector }}
+    podMonitorSelector:
+      {{- include "opentelemetry-target-allocator.podMonitorSelector" . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.targetAllocator.serviceMonitorSelector }}
+    serviceMonitorSelector:
+      {{- include "opentelemetry-target-allocator.serviceMonitorSelector" . | nindent 8 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-collector/templates/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/configmap-targetallocator.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "opentelemetry-collector.fullname" . }}
+  name: {{ include "opentelemetry-collector.fullname" . }}-targetallocator
   namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}

--- a/charts/opentelemetry-collector/templates/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/deployment-targetallocator.yaml
@@ -1,0 +1,83 @@
+{{- if not .Values.collectorCRD.generate -}}
+{{- if .Values.targetAllocator.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opentelemetry-collector.fullname" . }}-targetallocator
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  labels:
+    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.annotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.targetAllocator.replicas }}
+  selector:
+    matchLabels:
+      {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
+      {{- include "opentelemetry-collector.component" . | nindent 6 }}
+  strategy:
+    {{- if eq .Values.rollout.strategy "RollingUpdate" }}
+    {{- with .Values.rollout.rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
+    type: {{ .Values.rollout.strategy }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-targetallocator.yaml") . | sha256sum }}
+        {{- include "opentelemetry-collector.podAnnotations" . | nindent 8 }}
+      labels:
+        {{- include "opentelemetry-collector.selectorLabels" . | nindent 8 }}
+        {{- include "opentelemetry-collector.component" . | nindent 8 }}
+        {{- include "opentelemetry-collector.podLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "opentelemetry-collector.fullname" . }}-targetallocator
+          {{- if .Values.targetAllocator.image.tag }}
+          image: "{{ .Values.targetAllocator.image.repository }}:{{ .Values.targetAllocator.image.tag | default .Chart.AppVersion }}"
+          {{- else if .Values.targetAllocator.image.digest}}
+          image: "{{ .Values.targetAllocator.image.repository }}@{{ .Values.targetAllocator.image.digest }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.targetAllocator.image.pullPolicy }}
+          args:
+            {{- if .Values.targetAllocator.prometheusCR.enabled }}
+            - --enable-prometheus-cr-watcher
+            {{- end }}
+          env:
+          - name: OTELCOL_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP 
+          {{- if .Values.targetAllocator.serviceAccount }}
+          serviceAccountName: {{ .Values.targetAllocator.serviceAccount | quote }}
+          {{- else }}
+          serviceAccountName: {{ include "opentelemetry-collector.serviceAccountName" . }}-targetallocator
+          {{- end }}
+          {{- with .Values.targetAllocator.resources }}
+          resources:
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
+          volumeMounts:
+          - mountPath: /conf
+            name: ta-internal
+          volumes:
+          - configMap:
+              defaultMode: 420
+              items:
+              - key: targetallocator.yaml
+                path: targetallocator.yaml
+              name: {{ include "opentelemetry-collector.fullname" . }}-targetallocator
+            name: ta-internal
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-collector/templates/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/deployment-targetallocator.yaml
@@ -59,11 +59,6 @@ spec:
           - containerPort: 8080
             name: http
             protocol: TCP 
-          {{- if .Values.targetAllocator.serviceAccount }}
-          serviceAccountName: {{ .Values.targetAllocator.serviceAccount | quote }}
-          {{- else }}
-          serviceAccountName: {{ include "opentelemetry-collector.serviceAccountName" . }}-targetallocator
-          {{- end }}
           {{- with .Values.targetAllocator.resources }}
           resources:
             {{- toYaml . | nindent 6 }}
@@ -71,13 +66,18 @@ spec:
           volumeMounts:
           - mountPath: /conf
             name: ta-internal
-          volumes:
-          - configMap:
-              defaultMode: 420
-              items:
-              - key: targetallocator.yaml
-                path: targetallocator.yaml
-              name: {{ include "opentelemetry-collector.fullname" . }}-targetallocator
-            name: ta-internal
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: targetallocator.yaml
+            path: targetallocator.yaml
+          name: {{ include "opentelemetry-collector.fullname" . }}-targetallocator
+        name: ta-internal
+      {{- if .Values.targetAllocator.serviceAccount }}
+      serviceAccountName: {{ .Values.targetAllocator.serviceAccount | quote }}
+      {{- else }}
+      serviceAccountName: {{ include "opentelemetry-collector.serviceAccountName" . }}-targetallocator
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/templates/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/templates/opentelemetrycollector.yaml
@@ -16,38 +16,35 @@ spec:
   {{- if .Values.collectorCRD.updateStrategy }}
   updateStrategy: {{ .Values.collectorCRD.updateStrategy | quote }}
   {{- end }}
-  {{- if .Values.collectorCRD.targetAllocator.enabled }}
+  {{- if .Values.targetAllocator.enabled }}
   targetAllocator:
-    enabled: {{ .Values.collectorCRD.targetAllocator.enabled }}
-    {{- if .Values.collectorCRD.targetAllocator.prometheusCR.enabled }}
+    enabled: {{ .Values.targetAllocator.enabled }}
+    {{- if .Values.targetAllocator.prometheusCR.enabled }}
     prometheusCR:
       enabled: true
-      {{- if .Values.collectorCRD.targetAllocator.prometheusCR.podMonitorSelector }}
+      {{- if .Values.targetAllocator.prometheusCR.podMonitorSelector }}
       podMonitorSelector:
         {{- include "opentelemetry-target-allocator.podMonitorSelector" . | nindent 8 }}
       {{- end }}
-      {{- if .Values.collectorCRD.targetAllocator.prometheusCR.serviceMonitorSelector }}
+      {{- if .Values.targetAllocator.prometheusCR.serviceMonitorSelector }}
       serviceMonitorSelector:
         {{- include "opentelemetry-target-allocator.serviceMonitorSelector" . | nindent 8 }}
       {{- end }}
     {{- end }}
-    {{- if .Values.collectorCRD.allocationStrategy }}
-    allocationStrategy: {{ .Values.collectorCRD.allocationStrategy | quote }}
+    {{- if .Values.targetAllocator.allocationStrategy }}
+    allocationStrategy: {{ .Values.targetAllocator.allocationStrategy | quote }}
     {{- end }}
-    {{- if .Values.collectorCRD.filterStrategy }}
-    filterStrategy: {{ .Values.collectorCRD.filterStrategy | quote }}
-    {{- end }}
-    {{- if .Values.collectorCRD.serviceAccount }}
-    serviceAccount: {{ .Values.collectorCRD.serviceAccount | quote }}
+    {{- if .Values.targetAllocator.serviceAccount }}
+    serviceAccount: {{ .Values.targetAllocator.serviceAccount | quote }}
     {{- else }}
     serviceAccount: {{ include "opentelemetry-collector.serviceAccountName" . }}-targetallocator
     {{- end }}
-    {{- if .Values.collectorCRD.targetAllocator.image.tag }}
-    image: "{{ .Values.collectorCRD.targetAllocator.image.repository }}:{{ .Values.collectorCRD.targetAllocator.image.tag | default .Chart.AppVersion }}"
-    {{- else if .Values.collectorCRD.targetAllocator.image.digest}}
-    image: "{{ .Values.collectorCRD.targetAllocator.image.repository }}@{{ .Values.collectorCRD.targetAllocator.image.digest }}"
+    {{- if .Values.targetAllocator.image.tag }}
+    image: "{{ .Values.targetAllocator.image.repository }}:{{ .Values.targetAllocator.image.tag | default .Chart.AppVersion }}"
+    {{- else if .Values.targetAllocator.image.digest}}
+    image: "{{ .Values.targetAllocator.image.repository }}@{{ .Values.targetAllocator.image.digest }}"
     {{- end }}
-    {{- with .Values.collectorCRD.resources }}
+    {{- with .Values.targetAllocator.resources }}
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/opentelemetry-collector/templates/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/service-targetallocator.yaml
@@ -1,0 +1,26 @@
+{{- if not .Values.collectorCRD.generate -}}
+{{- if .Values.targetAllocator.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opentelemetry-collector.fullname" . }}-targetallocator
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
+  labels:
+    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+    {{- include "opentelemetry-collector.component" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  ports:
+  - name: targetallocation
+    port: 80
+    targetPort: http
+  selector:
+    {{- include "opentelemetry-collector.selectorLabels" . | nindent 4 }}
+    {{- include "opentelemetry-collector.component" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-collector/templates/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/serviceaccount-targetallocator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.collectorCRD.targetAllocator.enabled -}}
+{{- if and (.Values.targetAllocator.enabled) (not (.Values.targetAllocator.serviceAccount)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -47,6 +47,85 @@
       "type": "string",
       "enum": ["daemonset", "deployment", "statefulset", ""]
     },
+    "targetAllocator": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "prometheusCR": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "podMonitorSelector": {},
+            "serviceMonitorSelector": {}
+          }
+        },
+        "allocationStrategy": {
+          "type": "string",
+          "enum": ["least-weighted", "consistent-hashing", "per-node", ""]
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "digest": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["IfNotPresent", "Always", "Never"]
+            }
+          }
+        },
+        "serviceAccount": {
+          "type": "string"
+        },
+        "replicas": {
+          "type": "integer"
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "type": ["string", "integer"]
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "type": ["string", "integer"]
+                },
+                "memory": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "collectorCRD": {
       "type": "object",
       "additionalProperties": false,
@@ -83,82 +162,6 @@
                 },
                 "memory": {
                   "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "targetAllocator": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "prometheusCR": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "enabled": {
-                  "type": "boolean"
-                },
-                "podMonitorSelector": {},
-                "serviceMonitorSelector": {}
-              }
-            },
-            "allocationStrategy": {
-              "type": "string",
-              "enum": ["least-weighted", "consistent-hashing", ""]
-            },
-            "filterStrategy": {
-              "type": "string",
-              "enum": ["relabel-config", ""]
-            },
-            "image": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "repository": {
-                  "type": "string"
-                },
-                "tag": {
-                  "type": "string"
-                },
-                "digest": {
-                  "type": "string"
-                }
-              }
-            },
-            "serviceAccount": {
-              "type": "string"
-            },
-            "resources": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "limits": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "cpu": {
-                      "type": ["string", "integer"]
-                    },
-                    "memory": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "requests": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "cpu": {
-                      "type": ["string", "integer"]
-                    },
-                    "memory": {
-                      "type": "string"
-                    }
-                  }
                 }
               }
             }

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -16,35 +16,36 @@ collectorCRD:
   generate: false
   updateStrategy: ""
   resources: {}
-  # If the target allocator is enabled, the service account, cluster role
-  # and cluster role binding will be generated as well, with appropriate
-  # permissions, necessary for target allocator to work. If you do not
-  # wish to create these objects and would like to specify your own
-  # service account, provide it below.
-  targetAllocator:
-    enabled: false
-    prometheusCR:
-      enabled: false
-      podMonitorSelector: {}
-      serviceMonitorSelector: {}
-    allocationStrategy: ""
-    filterStrategy: ""
-    # Target allocator image defaults to repository and tag set by
-    # the operator (this should correspond to operator's version).
-    # Set appropriate values to override.
-    image:
-      repository: ""
-      tag: ""
-      digest: ""
-    # Name of the service account to be used by the target allocator.
-    # If set, no service account or cluster role for target allocator
-    # will be created.
-    serviceAccount: ""
-    resources: {}
-
 
 # Valid values are "daemonset", "deployment", and "statefulset".
 mode: ""
+
+# If the target allocator is enabled, the service account, cluster role
+# and cluster role binding will be generated as well, with appropriate
+# permissions, necessary for target allocator to work. If you do not
+# wish to create these objects and would like to specify your own
+# service account, provide it below.
+targetAllocator:
+  enabled: false
+  replicas: 1
+  prometheusCR:
+    enabled: false
+    podMonitorSelector: {}
+    serviceMonitorSelector: {}
+  allocationStrategy: ""
+  # Target allocator image defaults to repository and tag set by
+  # the operator (this should correspond to operator's version).
+  # Set appropriate values to override.
+  image:
+    repository: ""
+    pullPolicy: IfNotPresent
+    tag: ""
+    digest: ""
+  # Name of the service account to be used by the target allocator.
+  # If set, no service account or cluster role for target allocator
+  # will be created.
+  serviceAccount: ""
+  resources: {}
 
 # When using windows set this to true and make sure
 # to use collector image built for windows.


### PR DESCRIPTION
This PR makes changes to make it possible to deploy target allocator in a non-CRD mode (without OTEL operator).

- Adds TA deployment, configmap, service
- Adjusts parameters to better reflect this change (move target allocator config section out of CRD directly under `.Values`)
- Add examples