### PR TITLE
Bump collector version to `0.104.0`

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry Collector
 
+### v0.87.0 / 2024-07-03
+- [Feat] Bump collector version to `0.104.0`
+
 ### v0.86.2 / 2024-06-25
 - [Fix] Allow configuring max_unmatched_batch_size in multilineConfigs. Default is changed to max_unmatched_batch_size=1.
 - [Fix] Fix spanMetrics.spanNameReplacePattern preset does not work

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.86.2
+version: 0.87.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -13,4 +13,4 @@ icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 maintainers:
   - name: povilasv
   - name: matej-g
-appVersion: 0.102.1
+appVersion: 0.104.0

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dfeaddf8604062665514d0136990813ceef5940890ba3a481a3335a72ca57940
+        checksum/config: 7ccf0f6ad3e8b1510fb1cedf25d7c173ea03027bf6b2da950e60daae83b74510
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c4c818cc80a33b540743d691b1403780c5da498993ab38de5fd4377a3a9b1680
+        checksum/config: 55e6f546a3bbe63525b888898ee489d2162cef3bf4b81e3e4e65390624d0c167
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fb65e04424d9951ad8de4b54d02f54ff4e1f30ba2a87cc9cefe31ccaf06069c5
+        checksum/config: 58d4708e63e2213d8d15657009555bb755a0fe92a00458789aa697a0cd46858c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2cd407963844148cdf355761417b0714361f5f45b0783a10bd86b7c41ec22784
+        checksum/config: cf3364eaaba41953dbfdd1d2bc5f1690c4dd5a7efe49ef51e0701040ec4fc6c0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2cd407963844148cdf355761417b0714361f5f45b0783a10bd86b7c41ec22784
+        checksum/config: cf3364eaaba41953dbfdd1d2bc5f1690c4dd5a7efe49ef51e0701040ec4fc6c0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6bb2b14b2af00bb459fe5f6408c015d1681714a941fad645f29d36729bebc458
+        checksum/config: 2b8c426446cd901f96fb50b24270304e8a2da784e317370d863d8a6301432370
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -49,7 +49,7 @@ data:
             - targets:
               - ${env:MY_POD_IP}:8888
         target_allocator:
-          collector_id: ${MY_POD_NAME}
+          collector_id: ${env:MY_POD_NAME}
           endpoint: http://example-opentelemetry-collector-targetallocator
           interval: 30s
       zipkin:

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
 data:
   targetallocator.yaml: |

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4ef0e7082493e6f188aa3981226780a9013cdc9739b026122c3f489387ead80f
+        checksum/config: 68823e6b3148113a39ab4c8a570b34337aa6d9e1cba22d6df8385d1c822fce6e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 976e3e8235176b8b90e7a2bb25741cba5ca39f0d50096e582bb4aa7e6c2ac309
+        checksum/config: ab5d2c2b0a45571dcc3a7f17e195c6a28832c7106ff25389b2115264ae2ff842
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector-target-allocator

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     component: target-allocator
 spec:

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 90429afb7a6027c8274fa3bc27ab39546dd14a9db55100998e16dbd809e15acf
+        checksum/config: 4be973cbcee6ee03b0375bb111c93c0c921d086abdc7ec46ff36ab13737f763b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=C:\\conf\relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d92ef523803d1e4b377df6fd39c8ee450e971e178fa204f7c5fcb94717c0f158
+        checksum/config: d85072134dba474cfc5bc5efb8accdda8ac2637c2f27ca65a7d3a23bddec51f6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d1a1cff6b5427c52d4aa49c5baf3657a3a94dd02661fb1ec45d347cc02aa73b7
+        checksum/config: 8ed59b14915f75ca827cb3805765dfbd997e6ac342b5e0e1331b8b8f61030c3b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/config.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a90cef39507b875c8cf47199d98bfd548fdc69c709bafc568de70c37e2ec5b97
+        checksum/config: 26fb268219b9156f6dff69900c49c814ad1c673f38f9a3c238727d6183cdc35b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: agent-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a4f7f7ea3e991727b0cbf6546f1e0f10aeb046dc6de71524e7c42ba7f218b5cf
+        checksum/config: d383b19259c4c84c0c2df0faf82ebbe98a494544c957f52f90c2837d6a1adaf9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cdecf78888d5434c159c563fff5aad7d767b60610ec0ad7f7a98ee232f8a6533
+        checksum/config: c6cb5aaae2d837966fd8b00b0acf8e3e6eb83239c5819b0a6fe9b5e10353454c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 58e8b0c2de52d86c9770e4cf06f6ddc6aabaa65e8155b7d31b8b7f30faa34aad
+        checksum/config: 36862fd72ba3335b9e37f46e72ae19f92ac01428ba1ae36ae7d41a6c9d4ba112
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/integrations/mysql/opentelemetrycollector-sidecar.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/integrations/mysql/opentelemetrycollector-sidecar.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-mysql-logs-sidecar
 spec:
   mode: sidecar
-  image: "otel/opentelemetry-collector-contrib:0.102.1"
+  image: "otel/opentelemetry-collector-contrib:0.104.0"
   volumeMounts:
   - mountPath: /var/lib/mysql
     name: data

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
@@ -5,10 +5,10 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   podSecurityContext:
     runAsUser: 0
     runAsGroup: 0
-  image: "otel/opentelemetry-collector-contrib:0.102.1"
+  image: "otel/opentelemetry-collector-contrib:0.104.0"
   imagePullPolicy: IfNotPresent
   ports:
     - name: jaeger-compact
@@ -283,7 +283,7 @@ spec:
             - targets:
               - ${env:MY_POD_IP}:8888
         target_allocator:
-          collector_id: ${MY_POD_NAME}
+          collector_id: ${env:MY_POD_NAME}
           endpoint: http://example-opentelemetry-collector-targetallocator
           interval: 30s
       receiver_creator/mysql:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: default-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
@@ -5,10 +5,10 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -17,7 +17,7 @@ spec:
   podSecurityContext:
     runAsUser: 0
     runAsGroup: 0
-  image: "otel/opentelemetry-collector-contrib:0.102.1"
+  image: "otel/opentelemetry-collector-contrib:0.104.0"
   imagePullPolicy: IfNotPresent
   ports:
     - name: jaeger-binary

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: default
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 roleRef:

--- a/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2ceda4771768b539369b5f2758e6c6d4e31a510da4e9f08f786860cc9be760fe
+        checksum/config: 0bcb43d5649bbbb2f602a30a4ad83dd2526542303b48a31c049ff22dc815068d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6fddedf0731dbcb886b79e6fb0caccaa5d125d9ab24d83e1fa100fc59f15e4d0
+        checksum/config: 85eb63252bd79d58418b78ebdbe18f19c44e3ca892229a68eb79d80f28eb9f74
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -42,7 +42,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: statefulset-collector

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 34af9b2def260336e9a6239c996ed54fa4cfdb3d1f12c0eb6f272ca573aa960c
+        checksum/config: c222cc309caf3e5ee1e72b917d6c1b22de1e2730e3b55f342f1e8ef39c389c5b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -45,7 +45,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 data:

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d92ef523803d1e4b377df6fd39c8ee450e971e178fa204f7c5fcb94717c0f158
+        checksum/config: d85072134dba474cfc5bc5efb8accdda8ac2637c2f27ca65a7d3a23bddec51f6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector
@@ -44,7 +44,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.102.1"
+          image: "otel/opentelemetry-collector-contrib:0.104.0"
           imagePullPolicy: IfNotPresent
           ports:
             

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm
     
     component: standalone-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.86.2
+    helm.sh/chart: opentelemetry-collector-0.87.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.102.1"
+    app.kubernetes.io/version: "0.104.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -181,11 +181,11 @@ receivers:
         scrape_interval: 30s
         static_configs:
           - targets:
-              - ${MY_POD_IP}:8888
+              - ${env:MY_POD_IP}:8888
     target_allocator:
       endpoint: http://{{ include "opentelemetry-collector.fullname" . }}-targetallocator
       interval: 30s
-      collector_id: ${MY_POD_NAME}
+      collector_id: ${env:MY_POD_NAME}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyHostMetricsConfig" -}}


### PR DESCRIPTION
Bump collector and adjust the env vars in configuration to adhere to the expected convention (see notes in https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0)