### PR TITLE
fix(opentelemetry-collector): add missing hostmetrics process enabled condition

### DIFF
--- a/charts/opentelemetry-collector/templates/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/templates/opentelemetrycollector.yaml
@@ -54,9 +54,12 @@ spec:
   {{- end }}
     {{- include "opentelemetry-collector.podAnnotations" . | nindent 8 }}
   podSecurityContext:
-    {{- if and (not (.Values.securityContext)) (not (.Values.isWindows)) (.Values.presets.logsCollection.storeCheckpoints) }}
+    {{- if and (not (.Values.securityContext)) (not (.Values.isWindows)) (or (.Values.presets.logsCollection.storeCheckpoints) (.Values.presets.hostMetrics.process.enabled)) }}
     runAsUser: 0
     runAsGroup: 0
+    {{- if .Values.presets.hostMetrics.process.enabled }}
+    privileged: true
+    {{- end }}
     {{- else -}}
     {{- toYaml .Values.securityContext | nindent 6 }}
     {{- end }}
@@ -104,7 +107,7 @@ spec:
       value: {{ include "opentelemetry-collector.gomemlimit" .Values.resources.limits.memory | quote }}
     {{- end }}
     {{- with .Values.extraEnvs }}
-    {{- . | toYaml | nindent 4 }}
+    {{- . | toYaml | nindent 6 }}
     {{- end }}
   {{- if .Values.lifecycleHooks }}
   lifecycle:


### PR DESCRIPTION
When using the OTEL Operator, even when you enable the hostMetrics process flag, the privileged configuration is missing in the security context.