### PR TITLE
[opentelemetry-collector] add resource detection for k8s resource preset

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry Collector
 
+### v0.97.1 / 2024-11-05
+- [Feat] add aks/eks/gcp resource detecion for kubernetes resource collection.
+
 ### v0.97.0 / 2024-11-04
 - [Feat] logsCollection preset allow changing max_batch_size
 - [Fix] Revert collector version to `0.111.0` due to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.97.0
+version: 0.97.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56806755644611d54efa2d48882dceefe1249cf1be48af63ce1532d1e1ef6818
+        checksum/config: fdbb9dd66f72dc9de28e5984cf1353ada7287412f8f42b468515b84a4f37277b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7d4e43737f2f65f74f87329fcbc31788d116c7ea5544aa3354d0a13017732a06
+        checksum/config: 562a70de3479891ed6181cad1a346f203c8c9783cc15b567d6e0453cf7f9221b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb4f855af0c5a2e35fb44b59fef0af9105f2b239aab9fd7cb6b92ba242876a17
+        checksum/config: c8f412ff0d4a97801112b6549245a0ffc7052ea32ded8a8991525422346dcc59
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 67823ce5b26b74d3966bef4ea710275f41e2369415723721ffcd7461e1c9cae3
+        checksum/config: dd3ee952d40866ec9ceca6436f823e021f6f5fe287107a8bc28a3f9f42c5f8a8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 67823ce5b26b74d3966bef4ea710275f41e2369415723721ffcd7461e1c9cae3
+        checksum/config: dd3ee952d40866ec9ceca6436f823e021f6f5fe287107a8bc28a3f9f42c5f8a8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c5060a86fd7db6a5efbc62adaaf7912f2c45d1b5e1e2a4ce6588d7ec5527676
+        checksum/config: 30752901fd9f986d16255f521f664a5575acd6266009f070a9592bbfd28b2fee
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6b4b3c2985f2d64ba9336906f3aac4d2bb14a1510302f08e00f87f12b20d2fef
+        checksum/config: e986541d563aca01df355c5aa5ef712ad2ad224ee1fb3cc156db26bcfadac82b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b44ddeb6f1a05129c9e5088ae90ba5f23341f761b64e452faab4e53540db3ffc
+        checksum/config: 7bccbb4875fbc896ff3879c6925173908ef329fcfbbb8aa5d548f45dbf0102eb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector-target-allocator

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c8eea08a903e3525c9fa796eca0c4999429fcc14ff4b05b500fbf8fcaa7a999e
+        checksum/config: 9c4d04c7df8fb0ffbaafae55b7524a2da5973c837dabd56d3474bcb32b615747
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 471ada021794db22458d79e92ad513051f8f0cc3f06aaf7b0884326053cf71fa
+        checksum/config: 96482fe0d39b91e2699409c51c1d2b1a472801e4b212f4f0dbe3c1af21fbfa28
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f1b631ce1ac5acc6806d7b25bf91224ac8b51cc80946e858b56616c97a4acca1
+        checksum/config: fa9c9799ae40930777df755a95c99274a1e38db4bf0e94438914d469c4d6655f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0a466a7d4bfb91f46bf292fd0081e4539122098349b5c264d50941781dcd9b3f
+        checksum/config: 227b26d0f5bbbf4165bc0e18039e0ef6854aacdb8e9a239c8b01e0f5f9b34559
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb0e2a4b6e907f41bc0e54acd82d979634d91b80385e56eb2050b503e527f0da
+        checksum/config: ea73191c315313f6ab3388a204fd9c6dc17215f4cdc8debe7d9b05d7c0318239
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 10a8ff065636f5b25bd38bdb57a5734f89dd9d0d74ef3fb55e2a8feba63ac00d
+        checksum/config: b9cab29a0050f3d974672eebd03a0376adc2ca93df9722dc2d32af57f971393b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2c3fdd9396be1a0896961bfd353617de776066c2b98752a6dda8f18b682c433e
+        checksum/config: 7773b7ab3905e0b013ad665c8b62d31d984e640be69ba396ccbd5cd3a2ec8c46
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4dc2f369087231712997c7688254f04e2b5f0854b5d5996d5f6212eb8d7edcb8
+        checksum/config: 336fa83a7b05783530aab6b477a65b392f7808d36d463b814edc4d4b55ab540d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: default-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
@@ -5,13 +5,17 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
     app.kubernetes.io/managed-by: Helm
     
 rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["aws-auth"]
+    verbs: ["get"]
   - apiGroups: [""]
     resources:
     - namespaces

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -35,6 +35,23 @@ data:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resourcedetection/resource_catalog:
+        detectors:
+        - eks
+        - aks
+        - gcp
+        gcp:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+            k8s.cluster.name:
+              enabled: false
+        override: true
+        timeout: 2s
     receivers:
       jaeger:
         protocols:
@@ -196,6 +213,7 @@ data:
           - coralogix/resource_catalog
           processors:
           - memory_limiter
+          - resourcedetection/resource_catalog
           - resource/metadata
           - batch
           receivers:

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8c798813e319e75bc4e14cd1ea3ac927f4b32848f828a0687838354a4dfe84d0
+        checksum/config: e6f6baaf09e36cbc2e3051a2b0f54320efa2ba0b1c0715dcd82d181b6038951a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fb79479382a0c1c312f74e05660e1b89ed1d54d3a9382b88a5d2e3c5bd211467
+        checksum/config: 1d6a74a466d6040b0b08c4e2d0b7dfcd7935d5343270f34d6a1ad3098ebf38a3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8edba9a3b00bba10030fd3444679e469b38747c8a9881cd60d2a902a72222104
+        checksum/config: 96135beaf06f4dbbf736b68986e14eb2adf4f21a1a3634dec73ce4f2d045d1c8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3f0454281aa09bd0b44cacba222171ea48253ca44d54a9e9bb45b55fc058f117
+        checksum/config: d68db2858f982958f548767e39c7f30ee96d02e0f2972f45a117f70be1a5f5e6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 471ada021794db22458d79e92ad513051f8f0cc3f06aaf7b0884326053cf71fa
+        checksum/config: 96482fe0d39b91e2699409c51c1d2b1a472801e4b212f4f0dbe3c1af21fbfa28
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.97.0
+    helm.sh/chart: opentelemetry-collector-0.97.1
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.111.0"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -941,6 +941,24 @@ connectors:
 {{- end }}
 
 {{- define "opentelemetry-collector.kubernetesResourcesConfig" -}}
+processors:
+  resourcedetection/resource_catalog:
+    detectors:
+    - eks
+    - aks
+    - gcp
+    override: true
+    timeout: 2s
+    gcp:
+      resource_attributes:
+        host.id:
+          enabled: false
+        host.name:
+          enabled: false
+        host.type:
+          enabled: false
+        k8s.cluster.name:
+          enabled: false
 exporters:
   coralogix/resource_catalog:
     timeout: "30s"
@@ -1080,6 +1098,7 @@ service:
         - coralogix/resource_catalog
       processors:
         - memory_limiter
+        - resourcedetection/resource_catalog
         - resource/metadata
         - batch
       receivers:

--- a/charts/opentelemetry-collector/templates/clusterrole.yaml
+++ b/charts/opentelemetry-collector/templates/clusterrole.yaml
@@ -58,6 +58,10 @@ rules:
   {{- end }}
   {{- if .Values.presets.kubernetesResources.enabled }}
   - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["aws-auth"]
+    verbs: ["get"]
+  - apiGroups: [""]
     resources:
     - namespaces
     - nodes


### PR DESCRIPTION
Ref: https://coralogix.atlassian.net/browse/ES-382

Add cluster attributes for k8s resources.

Tested in eks, seems fine.

For azure and gcp - checked the code, I don't think we need any additional permissions 