### PR TITLE
[opentelemetry-integration] Add job name to pod associations for k8s attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .idea
+.DS_Store
 
 ### Helm ###
 **/charts/*.tgz

--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry Collector
 
+### v0.101.0 / 2024-12-31
+
+- [Feat] Add job name to pod association for k8s attributes.
+
 ### v0.99.0 / 2024-12-05
 - [Feat] Bump collector version to `0.115.1`
 

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.100.0
+version: 0.101.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9eb04d84f4ae983caec4c14e8b6cb791d9c1d4a0d033c23782dce6d03ce79667
+        checksum/config: 5347ee8ef7fb545373f4098a0a4603424158c5a9aac7e59c43fec70167c4ba82
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 13a1a21c66bbe0f2d49f515e1e7dfc69ec7bdd45758689022c98bb57c169e99a
+        checksum/config: af0f2b089fa1ef4e9a839083f44b9db5a3026def5579b64698aa20ebf84230ad
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 20be6079142d277e5c5776087be2aaf06ec390f9a54e9830ece5430053abcaa3
+        checksum/config: 2d3412434a0dc3ea89bfb06006cf58dd1fd553b530a4c84094ecc0b57e54b489
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be83a2cb29998dd72e23c429898a0443f41780ab86ba30bc2c78f13313dd2975
+        checksum/config: c4956ccc57c4b8c0cdb7a92db8f353f56e720f24b8b3d472143c9f1eb57680ce
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: be83a2cb29998dd72e23c429898a0443f41780ab86ba30bc2c78f13313dd2975
+        checksum/config: c4956ccc57c4b8c0cdb7a92db8f353f56e720f24b8b3d472143c9f1eb57680ce
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -102,6 +102,9 @@ data:
             name: k8s.pod.uid
         - sources:
           - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f4c3da820a8ce85ae07d39f11bb78d1ffb8ebba2dfec73f181bb6da1c906ebad
+        checksum/config: e0ac83425adb3b486de942789fe1dc0d41a15291f74bd6e11bf856255d157601
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e0ac83425adb3b486de942789fe1dc0d41a15291f74bd6e11bf856255d157601
+        checksum/config: a6a81dfbea4aa3f25ffbe906def8602f08a0bd04535c8e76743e9d253927fd77
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c7335aa10158b73257880d74afa143c2fd7faba51b6df67b571f8b5fa90b7513
+        checksum/config: feebc5c3b332b263691b8ca45a26bee16c68e222170106e4b1c43b7f1bdb9b5c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e28d186e0ae59a457719acd92afa92e8005169544e14f5080bec436c3fc70762
+        checksum/config: 27fc6f86afbcd72d21d4e5170b003c4babb0ca8775c272d7e7f581b95756842a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector-target-allocator

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 313265450c068f2390efd0dd768c249c45ebb5a3e332520e2afb1c4bdfade883
+        checksum/config: 284703511570e4c246c6e3ece6a3d0d2be0584445c1c28af3fe0b1e89686153d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 37e5637af51251b2970ff1c37acde3d906bb1aad39ee0c6612f4b42da9a5ebb7
+        checksum/config: 9d5f29459d14abe3502a621584fa6dd569c886f00c664d223be65a4d4d5ace98
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5c36719d5e674328c0fef37fe730c57e9a4d38b0f9faa06a2fa4258adaa96405
+        checksum/config: a633b37660e9d251c56e64ed42baa53cc1593db20244588c54f0871f9aa8c6c6
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6bf27a6f52eb1a79259fa373b80e15c7891435b4702e81571f3714c2a36fd32a
+        checksum/config: e03362769fa48f6077c6812f9d0abef8c0e47209581067cd82b850e252eed083
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ae0239cf2de3bf0ce194f26a0489877606ea3d3eeac8a01b33901c6db55b2b23
+        checksum/config: 8239a8e01542e93f92ad33e6e5dfc903022bba54df22841e325c957fcebca7a4
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -44,6 +44,9 @@ data:
             name: k8s.pod.uid
         - sources:
           - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 58dfd040d4695dd3f8a582a761dec0c0cb03bd358633ab74c60a1352bcd45d59
+        checksum/config: ad65cbf00769f54fddd428d2db90f1b292545a6419c5160ee97a7ee6db07d56b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ad65cbf00769f54fddd428d2db90f1b292545a6419c5160ee97a7ee6db07d56b
+        checksum/config: 6690bec73482dae7a4aec8087cc806c992d76970de93961ffba0927858a0f090
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 87c7699911e7c6fd1f5eeca710ee134ad237c176ee2aad37013562d835b74241
+        checksum/config: 8ee96cdeb69617ad051337aa98c33fe39c92707491c2b16119a227fe20fe883a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2defee59c72c66b278c5d4a3c6a37ca9ceddfb4510cb55d595899c58f0c9bf73
+        checksum/config: e53bb6557214864e0d209c50858514b41ca006d07cd65307fff42960bf912a87
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: default-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
@@ -155,6 +155,9 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 97bedfa101e6ac2c85c417eb6b821d82e63671f6b244ff91c174361bde139a56
+        checksum/config: daca4cf116e3f1e458b3acf5bdb505b0c835e438af924ab90f7015140d5b18cc
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
@@ -50,6 +50,9 @@ data:
             name: k8s.pod.uid
         - sources:
           - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80

--- a/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 030889569627ed8213468c8e792add6631637f705f7bd18073a06b07076009b2
+        checksum/config: 07743ebc10821826dcadfaebec08b6640946afae12f99691cbb57b4f69e93a44
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 039f2c03f94811faa9eceb59683c6ec41127d0c959523e471f8cbda2b02979ec
+        checksum/config: 030889569627ed8213468c8e792add6631637f705f7bd18073a06b07076009b2
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ad9ae55ba948309d7699d5eb49d7cd9245d458d39f2b825a1aefdfd1b0580552
+        checksum/config: dc3c2a21515ab68f4f42f3f295deb57e935b0e390e224024be1a8388ce87e57a
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d3e784e3ef32adcfb4d3f4e35c181aa35e7347607c7f3665d1ff252d60a82594
+        checksum/config: c0ca3112c60ffc0e645ebc6178f473ebcde4f9c8df298cdbca7188ce7e080e67
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 37e5637af51251b2970ff1c37acde3d906bb1aad39ee0c6612f4b42da9a5ebb7
+        checksum/config: 9d5f29459d14abe3502a621584fa6dd569c886f00c664d223be65a4d4d5ace98
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.100.0
+    helm.sh/chart: opentelemetry-collector-0.101.0
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.115.1"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -1309,6 +1309,9 @@ processors:
         name: k8s.pod.uid
     - sources:
       - from: connection
+    - sources:
+      - from: resource_attribute
+        name: k8s.job.name
     extract:
       metadata:
         - "k8s.namespace.name"


### PR DESCRIPTION
Fixes ES-401.

With this association the k8s attributes processor is able to pull in CronJob and Pod metadata into a Job metric.

Tested in a kind cluster, including through the shippers to confirm it works as expected in our backend.