### PR TITLE
[opentelemetry-collector] add extraLogReceivers

### DIFF
--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -23,6 +23,18 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -72,6 +84,8 @@ data:
           - batch
           receivers:
           - otlp
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - otlp

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2eece0588524230a5a31d5d902395a3af718a5f0ee40fbbce6887a18669e8666
+        checksum/config: 61b1375b0769fc5d4783977c73144123dec57d60dfbae3928bea941e085ee034
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -19,6 +19,18 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -126,6 +138,8 @@ data:
           - batch
           receivers:
           - otlp
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ad396f17f929a89d9b7b2f914f672801c9604b3574a08431b1007905d310cb1b
+        checksum/config: b8ac66f399d861addce6a55ef0a1fa085c6d295642f9c31522796a7baf0bd1d9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -19,6 +19,18 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -62,6 +74,8 @@ data:
           - batch
           receivers:
           - otlp
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e9b3ae3cb8c0b04ea60bcb91cb4de02a19034a0ca37d08cadb90731bdca5b612
+        checksum/config: d09f6886ac5785422e4aa292d13afd41467a44a76d4535950b780a276bbe556d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -19,6 +19,18 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -62,6 +74,8 @@ data:
           - batch
           receivers:
           - otlp
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e9b3ae3cb8c0b04ea60bcb91cb4de02a19034a0ca37d08cadb90731bdca5b612
+        checksum/config: d09f6886ac5785422e4aa292d13afd41467a44a76d4535950b780a276bbe556d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -61,6 +61,18 @@ data:
         auth_type: serviceAccount
         node: ${env:K8S_NODE_NAME}
         observe_pods: true
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       filter/db_spanmetrics:
@@ -424,6 +436,8 @@ data:
           receivers:
           - otlp
           - filelog
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c7ee41c5d37e3e0c89f16a987b38620dd38e382bb55b178a4e594899b1f177e9
+        checksum/config: cb1f274b864d187d40fb13d712b31c9896a1e8d35446bf0e0e2e6bfa8869e7ff
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -19,6 +19,18 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -66,6 +78,8 @@ data:
           - batch
           receivers:
           - otlp
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 643e24dec01aa5c97efdcabb73e45ff8fe7ff5bcddd9ec078d4bf33599fe1b81
+        checksum/config: 764f67dd00eac1273b399561a1bcd0d6f6cd743f5eadfb78696bc49ed6e4531e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
@@ -21,6 +21,18 @@ data:
         directory: /var/lib/otelcol
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -178,6 +190,8 @@ data:
           receivers:
           - otlp
           - filelog
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7732c327e02519d70f7e5d12ea1954e77f7cbcd477ba7bb66a374c777737b28f
+        checksum/config: fe385f6d3b9fb95817e3901c53d4e662af7cdb638644e63dce66e5cb08a2af90
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -23,6 +23,18 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -169,6 +181,8 @@ data:
           receivers:
           - otlp
           - filelog
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - otlp

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 63d73752f2bcd3a7ee7a2880ef14d541a0135f7784419f1e524b325075c3af31
+        checksum/config: f456afc6e68f2c9776ab337ee60961cf7d36086d5349f6cfb24880041947f629
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
@@ -42,6 +42,18 @@ data:
             headers:
               Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
             polling_interval: 2m
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -186,6 +198,8 @@ data:
           - batch
           receivers:
           - otlp
+          - otlp/2
+          - otlp/3
         logs/resource_catalog:
           exporters:
           - coralogix/resource_catalog

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d2ca6d14b5423517bbe973c5c6394b7f23f34b7f522f5e5ae6f669e290fa4d65
+        checksum/config: 87e37b6887b507c8d23ded0e6145b5d28c983c645d472ced359aa946e43d9c76
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
@@ -128,6 +128,18 @@ spec:
         directory: /var/lib/otelcol
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       k8sattributes:
@@ -392,6 +404,8 @@ spec:
           receivers:
           - otlp
           - filelog
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
@@ -82,6 +82,18 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+    otlp/2:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4315
+        http:
+          endpoint: ${env:MY_POD_IP}:4316
+    otlp/3:
+      protocols:
+        grpc:
+          endpoint: ${env:MY_POD_IP}:4317
+        http:
+          endpoint: ${env:MY_POD_IP}:4318
     processors:
       batch: {}
       memory_limiter:
@@ -125,6 +137,8 @@ data:
           - batch
           receivers:
           - otlp
+          - otlp/2
+          - otlp/3
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 06d74a2a77447d4d475cb1efa97bdad6b2424ef53c50e0c3e4625587702b7c15
+        checksum/config: 00749dd5e919297f2e17a8236c1893daeaa49db760c79dac3a2662a9bd955e10
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -91,6 +91,9 @@ Build config file for daemonset OpenTelemetry Collector
 {{- if .Values.presets.fleetManagement.enabled }}
 {{- $config = (include "opentelemetry-collector.applyFleetManagementConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
+{{- if .Values.extraLogReceivers }}
+{{- $config = (include "opentelemetry-collector.applyExtraLogReceivers" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
 {{- $config = (include "opentelemetry-collector.applyBatchProcessorAsLast" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- tpl (toYaml $config) . }}
 {{- end }}
@@ -185,6 +188,22 @@ Build config file for deployment OpenTelemetry Collector
 {{- end }}
 
 {{- $config | toYaml }}
+{{- end }}
+
+{{- define "opentelemetry-collector.applyExtraLogReceivers" -}}
+{{- $config := mustMergeOverwrite (include "opentelemetry-collector.extraLogReceivers" .Values | fromYaml) .config }}
+{{- range $key, $value := .Values.Values.extraLogReceivers }}
+{{- $_ := set $config.service.pipelines.logs "receivers" (append $config.service.pipelines.logs.receivers $key | uniq) }}
+{{- end }}
+{{- $config | toYaml }}
+{{- end }}
+
+{{- define "opentelemetry-collector.extraLogReceivers" -}}
+{{- $extraLogReceivers := .Values.extraLogReceivers }}
+{{- range $key, $value := $extraLogReceivers }}
+{{- $_ := set $extraLogReceivers $key $value }}
+{{- end }}
+{{- $extraLogReceivers | toYaml }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyTargetAllocatorConfig" -}}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -278,6 +278,10 @@
       "type": "string",
       "description": "Name of the namespace to deploy the resources into."
     },
+    "extraLogReceivers": {
+      "type": "object",
+      "additionalProperties": true
+    },
     "presets": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -299,6 +299,39 @@ configMap:
   # Specifies whether a configMap should be created (true by default)
   create: true
 
+# extraConfig:
+#   exporters:
+#     debug: {}
+#   receivers:
+#     otlp:
+#       protocols:
+#         grpc:
+#           endpoint: ${env:MY_POD_IP}:4317
+#         http:
+#           endpoint: ${env:MY_POD_IP}:4318
+#    service:
+#     pipelines:
+#       logs:
+#         processors:
+#           - memory_limiter
+#           - batch
+#         receivers:
+#           - otlp
+
+extraLogReceivers:
+  otlp/3:
+    protocols:
+      grpc:
+        endpoint: ${env:MY_POD_IP}:4317
+      http:
+        endpoint: ${env:MY_POD_IP}:4318
+  otlp/2:
+    protocols:
+      grpc:
+        endpoint: ${env:MY_POD_IP}:4315
+      http:
+        endpoint: ${env:MY_POD_IP}:4316
+
 # Base collector configuration.
 # Supports templating. To escape existing instances of {{ }}, use {{` <original content> `}}.
 # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.


### PR DESCRIPTION
POC1: Example config:

```
extraLogReceivers:
  otlp/3:
    protocols:
      grpc:
        endpoint: ${env:MY_POD_IP}:4317
      http:
        endpoint: ${env:MY_POD_IP}:4318
  otlp/2:
    protocols:
      grpc:
        endpoint: ${env:MY_POD_IP}:4315
      http:
        endpoint: ${env:MY_POD_IP}:4316
```