### PR TITLE
Fix namespace of targetallocator service account

### DIFF
--- a/charts/opentelemetry-collector/templates/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/serviceaccount-targetallocator.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opentelemetry-collector.serviceAccountName" . }}-targetallocator
+  namespace: {{ template "opentelemetry-collector.namespace" . }}
   labels:
     {{- include "opentelemetry-target-allocator.labels" . | nindent 4 }}
 {{ end }}


### PR DESCRIPTION
Previously, the targetallocator's service account did not get an explicitly defined namespace.

This breaks specifying the namespace at the helm level.