### PR TITLE
Fix memory suffix for EiB parsing

### DIFF
--- a/charts/opentelemetry-collector/templates/_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_helpers.tpl
@@ -223,7 +223,7 @@ Allow the release namespace to be overridden
   {{- if hasSuffix "e" $mem -}}
     {{- $mem = mulf (trimSuffix "e" $mem | float64) 1e18 -}}
   {{- else if hasSuffix "ei" $mem -}}
-    {{- $mem = mulf (trimSuffix "e" $mem | float64) 0x1p60 -}}
+    {{- $mem = mulf (trimSuffix "ei" $mem | float64) 0x1p60 -}}
   {{- else if hasSuffix "p" $mem -}}
     {{- $mem = mulf (trimSuffix "p" $mem | float64) 1e15 -}}
   {{- else if hasSuffix "pi" $mem -}}


### PR DESCRIPTION
## Summary
- fix handling of `ei` memory suffix in `convertMemToBytes`

## Testing
- `make check-examples` *(fails: helm not found)*