### PR TITLE
Opentelemetry ebpf instrumentation

### DIFF
--- a/.github/workflows/release-ebpf-instrumentations.yaml
+++ b/.github/workflows/release-ebpf-instrumentations.yaml
@@ -1,0 +1,36 @@
+name: Coralogix-OpenTelemetry-ebpf-instrumentation-Helm-Chart
+on:
+  push:
+    branches: main
+    paths:
+    - 'charts/opentelemetry-ebpf-instrumentation/**'
+
+env:
+  CHART_VERSION: $(yq eval '.version' charts/opentelemetry-ebpf-instrumentation/Chart.yaml)
+  CHART_NAME: opentelemetry-ebpf-instrumentation
+  ARTIFACTORY_URL: https://cgx.jfrog.io/artifactory/
+  ARTIFACTORY_USERNAME: integrations-actions
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Setup Helm Repo
+        run: |
+          cd charts/opentelemetry-ebpf-instrumentation
+          helm package .
+      -
+        name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v2.1.0
+        with:
+          version: 2.12.1
+      -
+        name: use-jfrog-cli
+        run: |
+          cd charts/opentelemetry-ebpf-instrumentation
+          jfrog rt upload --access-token ${{ secrets.ARTIFACTORY_NONUSER_ACCESS_TOKEN }} "${{ env.CHART_NAME }}-*.tgz" coralogix-charts --url ${{ env.ARTIFACTORY_URL }}
+

--- a/charts/opentelemetry-ebpf-instrumentation/.helmignore
+++ b/charts/opentelemetry-ebpf-instrumentation/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v2
+name: opentelemetry-ebpf-instrumentation
+version: 0.1.0
+description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
+type: application
+home: https://opentelemetry.io/
+sources:
+  - https://github.com/coralogix/opentelemetry-helm-charts
+  - https://github.com/open-telemetry/opentelemetry-helm-charts
+icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
+maintainers:
+  - name: nimrodavni78
+appVersion: 0.1.0

--- a/charts/opentelemetry-ebpf-instrumentation/README.md
+++ b/charts/opentelemetry-ebpf-instrumentation/README.md
@@ -1,0 +1,23 @@
+# OpenTelemetry Collector eBPF Helm Chart
+
+The helm chart installs [OpenTelemetry eBPF Instrumentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation)
+in kubernetes cluster.
+
+## Installing the Chart
+
+Add OpenTelemetry Helm repository:
+
+```console
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+```
+
+To install the chart with the release name my-opentelemetry-ebpf, run the following command:
+
+```console
+helm install my-opentelemetry-ebpf-instrumentation open-telemetry/opentelemetry-ebpf-instrumentation
+```
+
+### Other configuration options
+
+The [values.yaml](./values.yaml) file contains information about all other configuration
+options for this chart.

--- a/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/_helpers.tpl
@@ -1,0 +1,135 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "obi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "obi.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "obi.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "obi.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "obi.labels" -}}
+helm.sh/chart: {{ include "obi.chart" . }}
+{{ include "obi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: obi
+{{- end }}
+
+{{/*
+Selector (pod) labels
+*/}}
+{{- define "obi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "obi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "obi.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "obi.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Calculate name of image ID to use for "obi".
+*/}}
+{{- define "obi.imageId" -}}
+{{- if .Values.image.digest }}
+{{- $digest := .Values.image.digest }}
+{{- if not (hasPrefix "sha256:" $digest) }}
+{{- $digest = printf "sha256:%s" $digest }}
+{{- end }}
+{{- printf "@%s" $digest }}
+{{- else if .Values.image.tag }}
+{{- printf ":%s" .Values.image.tag }}
+{{- else }}
+{{- printf ":%s" .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+{{/*
+Calculate name of image ID to use for "obi-cache".
+*/}}
+{{- define "obi.k8sCache.imageId" -}}
+{{- if .Values.k8sCache.image.digest }}
+{{- $digest := .Values.k8sCache.image.digest }}
+{{- if not (hasPrefix "sha256:" $digest) }}
+{{- $digest = printf "sha256:%s" $digest }}
+{{- end }}
+{{- printf "@%s" $digest }}
+{{- else if .Values.k8sCache.image.tag }}
+{{- printf ":%s" .Values.k8sCache.image.tag }}
+{{- else }}
+{{- printf ":%s" .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common kube cache labels
+*/}}
+{{- define "obi.cache.labels" -}}
+helm.sh/chart: {{ include "obi.chart" . }}
+{{ include "obi.cache.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: obi
+{{- end }}
+
+{{/*
+Selector (pod) labels
+*/}}
+{{- define "obi.cache.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Values.k8sCache.service.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.k8sCache.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/cache-deployment.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/cache-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-        - name: ebpf-instrument-cache
+        - name: obi-k8s-cache
           image: {{ .Values.global.image.registry | default .Values.k8sCache.image.registry }}/{{ .Values.k8sCache.image.repository }}{{ include "obi.k8sCache.imageId" . }}
           imagePullPolicy: {{ .Values.k8sCache.image.pullPolicy }}
           ports:

--- a/charts/opentelemetry-ebpf-instrumentation/templates/cache-deployment.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/cache-deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.k8sCache.replicas }}
+{{- $root := . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.k8sCache.service.name }}
+  namespace: {{ include "obi.namespace" .}}
+  labels:
+    {{- include "obi.cache.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workload
+  {{- with .Values.k8sCache.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.k8sCache.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.k8sCache.service.name }}
+  template:
+    metadata:
+      {{- with .Values.k8sCache.podAnnotations }}
+      annotations:
+        {{- tpl (toYaml . | nindent 8) $root }}
+      {{- end }}
+      labels:
+        {{- include "obi.cache.labels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "obi.serviceAccountName" . }}
+      {{- end }}
+      {{- if or .Values.global.image.pullSecrets .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- if .Values.global.image.pullSecrets }}
+        {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
+        {{- else }}
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: ebpf-instrument-cache
+          image: {{ .Values.global.image.registry | default .Values.k8sCache.image.registry }}/{{ .Values.k8sCache.image.repository }}{{ include "obi.k8sCache.imageId" . }}
+          imagePullPolicy: {{ .Values.k8sCache.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.k8sCache.service.port }}
+              protocol: TCP
+              name: grpc
+          {{- if .Values.k8sCache.profilePort }}
+            - name: profile
+              containerPort: {{ .Values.k8sCache.profilePort }}
+              protocol: TCP
+          {{- end }}
+          {{- if .Values.k8sCache.internalMetrics.port }}
+            - name: {{ .Values.k8sCache.internalMetrics.portName }}
+              containerPort: {{ .Values.k8sCache.internalMetrics.port }}
+              protocol: TCP
+          {{- end }}
+          {{- with .Values.k8sCache.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: OTEL_EBPF_K8S_CACHE_PORT
+              value: "{{ .Values.k8sCache.service.port }}"
+          {{- if .Values.k8sCache.profilePort }}
+            - name: OTEL_EBPF_K8S_CACHE_PROFILE_PORT
+              value: "{{ .Values.k8sCache.profilePort }}"
+          {{- end }}
+          {{- if .Values.k8sCache.internalMetrics.port }}
+            - name: OTEL_EBPF_K8S_CACHE_INTERNAL_METRICS_PROMETHEUS_PORT
+              value: "{{ .Values.k8sCache.internalMetrics.port }}"
+          {{- end }}
+          {{- range $key, $value := .Values.k8sCache.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+          {{- end }}
+          {{- range $key, $value := .Values.k8sCache.envValueFrom }}
+            - name: {{ $key | quote }}
+              valueFrom:
+          {{- tpl (toYaml $value) $ | nindent 16 }}
+          {{- end }}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/cache-service.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/cache-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.k8sCache.replicas }}
+{{- $root := . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.k8sCache.service.name }}
+  namespace: {{ include "obi.namespace" .}}
+  labels:
+    {{- include "obi.cache.labels" . | nindent 4 }}
+    app.kubernetes.io/component: networking
+    {{- with .Values.k8sCache.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $root }}
+  {{- end }}
+spec:
+  ports:
+    - port: {{ .Values.k8sCache.service.port }}
+      protocol: TCP
+      targetPort: grpc
+      name: grpc
+  selector:
+    app.kubernetes.io/name: {{ .Values.k8sCache.service.name }}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/cluster-role-binding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/cluster-role-binding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "obi.fullname" . }}
+  labels:
+    {{- include "obi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "obi.serviceAccountName" . }}
+    namespace: {{ include "obi.namespace" .}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "obi.fullname" . }}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/cluster-role.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/cluster-role.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "obi.fullname" . }}
+  labels:
+    {{- include "obi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [ "apps" ]
+    resources: [ "replicasets" ]
+    verbs: [ "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "pods", "services", "nodes" ]
+    verbs: [ "list", "watch", "get" ]
+  {{- with .Values.rbac.extraClusterRoleRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end}}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
@@ -1,0 +1,37 @@
+{{- if not .Values.config.skipConfigMapCheck }}
+{{- if and (not .Values.config.create) (eq .Values.config.name "") }}
+  {{- fail "if .Values.config.name is not set, then .Values.config.create should be set to true to use default configuration" }}
+{{- end }}
+{{- end }}
+{{- if and (.Values.config.create) (eq .Values.config.name "") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "obi.fullname" . }}
+  namespace: {{ include "obi.namespace" . }}
+  labels:
+    {{- include "obi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  ebpf-instrument-config.yml: |
+    {{- if eq .Values.preset "network" }}
+    {{- if not .Values.config.data.network }}
+    network:
+      enable: true
+    {{- end }}
+    {{- end }}
+    {{- if eq .Values.preset "application" }}
+    {{- if not .Values.config.data.discovery }}
+    discovery:
+      services:
+        - k8s_namespace: .
+      exclude_services:
+        - exe_path: ".*ebpf-instrument.*|.*otelcol.*"
+    {{- end }}
+    {{- end }}
+  {{- toYaml .Values.config.data | nindent 4}}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/daemon-set.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/daemon-set.yaml
@@ -1,0 +1,148 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "obi.fullname" . }}
+  namespace: {{ include "obi.namespace" .}}
+  labels:
+    {{- include "obi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workload
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "obi.selectorLabels" . | nindent 6 }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obi.labels" . | nindent 8 }}
+        app.kubernetes.io/component: workload
+    spec:
+     {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "obi.serviceAccountName" . }}
+     {{- end }}
+      {{- if eq .Values.preset "application" }}
+      hostPID: true
+      {{- end }}
+      {{- if or (eq .Values.preset "network") .Values.config.data.network }}
+      hostNetwork: true
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.initContainers }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: ebpf-instrument
+          image: {{ .Values.global.image.registry | default .Values.image.registry }}/{{ .Values.image.repository }}{{ include "obi.imageId" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+          {{- if .Values.privileged }}
+          {{- with .Values.securityContext }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
+            runAsUser: 0
+            readOnlyRootFilesystem: true
+            capabilities:
+              add:
+                - BPF
+                - SYS_PTRACE
+                - NET_RAW
+                - CHECKPOINT_RESTORE
+                - DAC_READ_SEARCH
+                - PERFMON
+              {{- with .Values.extraCapabilities }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              drop:
+                - ALL
+          {{- end }}
+          ports:
+          {{- if or (.Values.service.targetPort) (.Values.config.data.prometheus_export) }}
+          - name: {{ .Values.service.portName }}
+            containerPort: {{ .Values.service.targetPort | default .Values.config.data.prometheus_export.port }}
+            protocol: TCP
+          {{- end }}
+          {{- if (and (or (.Values.service.internalMetrics.targetPort) ((and .Values.config.data.internal_metrics .Values.config.data.internal_metrics.prometheus))) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}
+          - name: {{ .Values.service.internalMetrics.portName }}
+            containerPort: {{ .Values.service.internalMetrics.targetPort | default .Values.config.data.internal_metrics.prometheus.port }}
+            protocol: TCP
+          {{- end }}
+          {{- if .Values.config.data.profile_port }}
+          - name: profile
+            containerPort: {{ .Values.config.data.profile_port }}
+            protocol: TCP
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: OTEL_EBPF_CONFIG_PATH
+              value: "/etc/ebpf-instrument/config/ebpf-instrument-config.yml"
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          {{- if .Values.k8sCache.replicas }}
+            - name: OTEL_EBPF_KUBE_META_CACHE_ADDRESS
+              value: {{ .Values.k8sCache.service.name }}:{{ .Values.k8sCache.service.port }}
+          {{- end }}
+          {{- range $key, $value := .Values.envValueFrom }}
+            - name: {{ $key | quote }}
+              valueFrom:
+          {{- tpl (toYaml $value) $ | nindent 16 }}
+          {{- end }}
+          {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+          {{- end }}
+          volumeMounts:
+            - mountPath: /etc/ebpf-instrument/config
+              name: ebpf-instrument-config
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if or .Values.global.image.pullSecrets .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- if .Values.global.image.pullSecrets }}
+        {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
+        {{- else }}
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: ebpf-instrument-config
+          configMap:
+            name: {{ default (include "obi.fullname" .) .Values.config.name }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/service.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/service.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.service.enabled }}
+{{- $root := . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obi.fullname" . }}
+  namespace: {{ include "obi.namespace" .}}
+  labels:
+    {{- include "obi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: networking
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $root }}
+  {{- end }}
+spec:
+  {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- else if eq .Values.service.type "LoadBalancer" }}
+  type: LoadBalancer
+  {{- with .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  type: {{ .Values.service.type }}
+  {{- end }}
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  ports:
+    {{- if or (.Values.service.targetPort) (.Values.config.data.prometheus_export) }}
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.service.targetPort | default .Values.config.data.prometheus_export.port }}
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+    {{- end }}
+    {{- if (and (or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics)) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}
+    - name: {{ .Values.service.internalMetrics.portName }}
+      port: {{ .Values.service.internalMetrics.port }}
+      protocol: TCP
+      targetPort: {{ .Values.service.internalMetrics.targetPort | default .Values.config.data.internal_metrics.prometheus.port }}
+      {{- with .Values.service.internalMetrics.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.internalMetrics.nodePort))) }}
+      nodePort: {{ .Values.service.internalMetrics.nodePort }}
+      {{- end }}
+    {{- end }}
+  selector:
+    {{- include "obi.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "obi.serviceAccountName" . }}
+  namespace: {{ include "obi.namespace" .}}
+  labels:
+    {{- include "obi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/servicemonitor.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.service.enabled .Values.serviceMonitor.enabled .Values.config.data.prometheus_export }}
+{{- $root := . }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "obi.fullname" . }}
+  namespace: {{ include "obi.namespace" .}}
+  labels:
+    {{- include "obi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- tpl (toYaml . | nindent 4) $root }}
+  {{- end }}
+spec:
+  endpoints:
+    {{- if or (.Values.service.targetPort) (.Values.config.data.prometheus_export) }}
+    - port: {{ .Values.service.portName }}
+      path: {{ .Values.config.data.prometheus_export.path }}
+      scheme: http
+      {{- with .Values.serviceMonitor.endpoint }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+    {{- if (and (or (.Values.service.internalMetrics.targetPort) (.Values.config.data.internal_metrics)) (not (eq .Values.config.data.prometheus_export.port .Values.config.data.internal_metrics.prometheus.port))) }}
+    - port: {{ .Values.service.internalMetrics.portName }}
+      path: {{ .Values.config.data.internal_metrics.prometheus.path }}
+      scheme: http
+      {{- with .Values.serviceMonitor.internalMetrics.endpoint }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | default (include "obi.fullname" .) }}
+  selector:
+    matchLabels:
+      {{- include "obi.labels" . | nindent 6 }}
+      {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -1,0 +1,337 @@
+## Global properties for image pulling override the values defined under `image.registry`.
+## If you want to override only one image registry, use the specific fields but if you want to override them all, use `global.image.registry`
+global:
+  image:
+    # -- Global image registry to use if it needs to be overridden for some specific use cases (e.g local registries, custom images, ...)
+    registry: ""
+    # -- Optional set of global image pull secrets.
+    pullSecrets: []
+
+image:
+  # -- Opentelemetry eBPF Instrumentation image registry (defaults to docker.io)
+  registry: "docker.io"
+  # -- Opentelemetry eBPF Instrumentation image repository.
+  repository: otel/ebpf-instrument
+  # -- (string) Opentelemetry eBPF Instrumentation image tag. When empty, the Chart's appVersion is
+  # used.
+  tag: main
+  # -- Opentelemetry eBPF Instrumentation image's SHA256 digest (either in format "sha256:XYZ" or "XYZ"). When set, will override `image.tag`.
+  digest: null
+  # -- Opentelemetry eBPF Instrumentation image pull policy.
+  pullPolicy: IfNotPresent
+  # -- Optional set of image pull secrets.
+  pullSecrets: []
+
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname.
+fullnameOverride: ""
+
+# -- Override the deployment namespace
+namespaceOverride: ""
+
+## DaemonSet annotations
+# annotations: {}
+
+rbac:
+  # -- Whether to create RBAC resources for Opentelemetry eBPF Instrumentation
+  create: true
+  # -- Extra custer roles to be created for Opentelemetry eBPF Instrumentation
+  extraClusterRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # -- ServiceAccount labels.
+  labels: {}
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podSecurityContext: {}
+# fsGroup: 2000
+
+# -- If set to false, deploys an unprivileged / less privileged setup.
+privileged: true
+
+# -- Extra capabilities for unprivileged / less privileged setup.
+extraCapabilities: []
+  # - SYS_RESOURCE       # <-- pre 5.11 only. Allows Opentelemetry eBPF Instrumentation to increase the amount of locked memory.
+# - SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+
+# -- Security context for privileged setup.
+securityContext:
+  privileged: true
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+priorityClassName: ""
+  # system-node-critical
+# system-cluster-critical
+
+## -- Expose the Opentelemetry eBPF Instrumentation Prometheus and internal metrics service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  # -- whether to create a service for metrics
+  enabled: false
+  # -- type of the service
+  type: ClusterIP
+  # -- Service annotations.
+  annotations: {}
+  # -- Service labels.
+  labels: {}
+  # -- cluster IP
+  clusterIP: ""
+  # -- loadbalancer IP
+  loadBalancerIP: ""
+  # -- loadbalancer class name
+  loadBalancerClass: ""
+  # -- source ranges for loadbalancer
+  loadBalancerSourceRanges: []
+  # -- Prometheus metrics service port
+  port: 80
+  # -- targetPort overrides the Prometheus metrics port. It defaults to the value of `prometheus_export.port`
+  # from the Opentelemetry eBPF Instrumentation configuration file.
+  targetPort: null
+  # -- name of the port for Prometheus metrics.
+  portName: metrics
+  # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
+  internalMetrics:
+    # -- internal metrics service port
+    port: 8080
+    # -- targetPort overrides the internal metrics port. It defaults to the value of `internal_metrics.prometheus.port`
+    # from the Opentelemetry eBPF Instrumentation configuration file.
+    targetPort: null
+    # -- name of the port for internal metrics.
+    portName: int-metrics
+    # -- Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+
+## -- See `kubectl explain daemonset.spec.updateStrategy` for more
+## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy
+updateStrategy:
+  # -- update strategy type
+  type: RollingUpdate
+
+# -- Additional volumes on the output daemonset definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# -- Additional volumeMounts on the output daemonset definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+# -- The nodeSelector field allows user to constrain which nodes your DaemonSet pods are scheduled to based on labels on the node
+nodeSelector: {}
+
+# -- Tolerations allow pods to be scheduled on nodes with specific taints
+tolerations: []
+
+# -- used for scheduling of pods based on affinity rules
+affinity: {}
+
+# -- Adds custom annotations to the Opentelemetry eBPF Instrumentation Pods.
+podAnnotations: {}
+
+# -- Adds custom labels to the Opentelemetry eBPF Instrumentation Pods.
+podLabels: {}
+
+## https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+# -- Determines how DNS resolution is handled for that pod.
+# If `.Values.preset` is set to `network` or `.Values.config.data.network` is enabled, Opentelemetry eBPF Instrumentation requires `hostNetwork` access, causing cluster service DNS resolution to fail.
+# It is recommended not to change this if Opentelemetry eBPF Instrumentation sends traces and metrics to Grafana components via k8s service.
+dnsPolicy: ClusterFirstWithHostNet
+
+## The below default configuration
+## 1. looks for ALL the services in the host
+## 2. export metrics as prometheus metrics by default at 9090 port
+## 3. enables kubernetes attribute
+## Note: The default configuration is used if config.create=true and config.name=""
+config:
+  # -- set to true, to skip the check around the ConfigMap creation
+  skipConfigMapCheck: false
+  # -- set to true, to use the below default configurations
+  create: true
+  ## -- Provide the name of the external configmap containing the Opentelemetry eBPF Instrumentation configuration.
+  ## To create configmap from configuration file, user can use the below command. Note: The name 'ebpf-instrument-config.yaml' is important.
+  ## `kubectl create cm --from-file=ebpf-instrument-config.yaml=<name-of-config-file> -n <namespace>`
+  ## If empty, default configuration below is used.
+  name: ""
+  # -- default value of Opentelemetry eBPF Instrumentation configuration
+  data:
+    # profile_port: 6060
+    # open_port: 8443
+    # routes:
+    #   unmatched: heuristic
+    # log_level: info
+    ## or alternatively use
+    # grafana:
+    #   otlp:
+    #     cloud_zone: prod-eu-west-0
+    #     cloud_instance_id: 123456
+    #     cloud_api_key:
+    otel_traces_export:
+      endpoint: "http://${HOST_IP}:4317"
+    otel_metrics_export:
+      endpoint: "http://${HOST_IP}:4318"
+    attributes:
+      kubernetes:
+        enable: false
+    filter:
+      network:
+        k8s_dst_owner_name:
+          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+        k8s_src_owner_name:
+          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+    ## to enable network metrics
+    # network:
+    #   enable: true
+    prometheus_export:
+      port: 9090
+      path: /metrics
+    ## to enable internal metrics
+    # internal_metrics:
+    #   prometheus:
+    #     port: 6060
+    #     path: /metrics
+
+## Env variables that will override configmap values
+## For example:
+##   OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT: 9090
+# -- extra environment variables
+env: {}
+  # OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT: 9090
+# OTEL_EBPF_TRACE_PRINTER: "text"
+
+# -- extra environment variables to be set from resources such as k8s configMaps/secrets
+envValueFrom: {}
+  #  ENV_NAME:
+  #    secretKeyRef:
+  #      name: secret-name
+#      key: value_key
+
+# -- Preconfigures some default properties for network or application observability.
+# Accepted values are "network" or "application".
+preset: application
+
+# -- Enable creation of ServiceMonitor for scraping of prometheus HTTP endpoint
+serviceMonitor:
+  enabled: false
+  # -- Add custom labels to the ServiceMonitor resource
+  additionalLabels: {}
+  # -- ServiceMonitor annotations
+  annotations: {}
+  metrics:
+    # -- ServiceMonitor Prometheus scraping endpoint.
+    # Target port and path is set based on service and `prometheus_export` values.
+    # For additional values, see the ServiceMonitor spec
+    endpoint:
+      interval: 15s
+  internalMetrics:
+    # -- ServiceMonitor internal metrics scraping endpoint.
+    # Target port and path is set based on service and `internal_metrics` values.
+    # For additional values, see the ServiceMonitor spec
+    endpoint:
+      interval: 15s
+  # -- Prometheus job label.
+  # If empty, chart release name is used
+  jobLabel: ""
+
+# -- Options to deploy the Kubernetes metadata cache as a separate service
+k8sCache:
+  # -- Number of replicas for the Kubernetes metadata cache service. 0 disables the service.
+  replicas: 0
+  # -- Enables the profile port for the Opentelemetry eBPF Instrumentation cache
+  profilePort: 0
+  ## Env variables that will override configmap values
+  ## For example:
+  ##   Opentelemetry eBPF Instrumentation_K8S_CACHE_LOG_LEVEL: "debug"
+  # -- extra environment variables
+  env: {}
+  # Opentelemetry eBPF Instrumentation_K8S_CACHE_LOG_LEVEL: "debug"
+
+  # -- extra environment variables to be set from resources such as k8s configMaps/secrets
+  envValueFrom: {}
+    #  ENV_NAME:
+    #    secretKeyRef:
+    #      name: secret-name
+  #      key: value_key
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+  #   memory: 128Mi
+  image:
+    # -- K8s Cache image registry (defaults to docker.io)
+    registry: "docker.io"
+    # -- K8s Cache image repository.
+    # TODO remove k8s cache?
+    repository: grafana/beyla-k8s-cache
+    # -- (string) K8s Cache image tag. When empty, the Chart's appVersion is used.
+    tag: null
+    # -- K8s Cache image's SHA256 digest (either in format "sha256:XYZ" or "XYZ"). When set, will override `image.tag`.
+    digest: null
+    # -- K8s Cache image pull policy.
+    pullPolicy: IfNotPresent
+    # -- Optional set of image pull secrets.
+    pullSecrets: []
+  service:
+    # -- Name of both the Service and Deployment
+    name: otel-ebpf-k8s-cache
+    # -- Port of the Kubernetes metadata cache service.
+    port: 50055
+    # -- Service annotations.
+    annotations: {}
+    # -- Service labels.
+    labels: {}
+  internalMetrics:
+    # 0: disabled by default
+    port: 0
+    path: /metrics
+    portName: metrics
+    #  prometheus:
+    #     port: 6060
+    #     path: /metrics
+  # -- Deployment annotations.
+  annotations: {}
+  # -- Adds custom annotations to the Opentelemetry eBPF Instrumentation Kube Cache Pods.
+  podAnnotations: {}
+  # -- Adds custom labels to the Opentelemetry eBPF Instrumentation Kube Cache Pods.
+  podLabels: {}

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -305,7 +305,7 @@ k8sCache:
     # TODO remove k8s cache?
     repository: grafana/beyla-k8s-cache
     # -- (string) K8s Cache image tag. When empty, the Chart's appVersion is used.
-    tag: null
+    tag: 2.2.4
     # -- K8s Cache image's SHA256 digest (either in format "sha256:XYZ" or "XYZ"). When set, will override `image.tag`.
     digest: null
     # -- K8s Cache image pull policy.


### PR DESCRIPTION
this is a direct port of the [beyla helm chart](https://github.com/grafana/beyla/blob/main/charts/beyla/README.md) to use  the new [opentelemetry ebpf instrumentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation) project

k8s cache image is still in beyla repo, until [there is a k8s-cache image in otel](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/115)