### PR TITLE
Chore/obi new k8s cache image

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+++ b/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v0.1.1 / 2025-06-17
 - [Feat] Use new `otel/opentelemetry-ebpf-k8s-cache` image instead of beyla one
+- [Fix] rename `otel-ebpf-k8s-cache` to `opentelemetry-ebpf-instrumentation-k8s-cache`
 
 ### v0.1.0 / 2025-06-15
 - [Feat] New chart for OpenTelemetry eBPF Instrumentation

--- a/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+++ b/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## OpenTelemetry eBPF Instrumentation
+### v0.1.0 / 2025-06-15
+- [Feat] New chart for OpenTelemetry eBPF Instrumentation

--- a/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+++ b/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
 ## OpenTelemetry eBPF Instrumentation
+
+### v0.1.1 / 2025-06-17
+- [Feat] Use new `otel/opentelemetry-ebpf-k8s-cache` image instead of beyla one
+
 ### v0.1.0 / 2025-06-15
 - [Feat] New chart for OpenTelemetry eBPF Instrumentation

--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.1.0
+version: 0.1.1
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -11,4 +11,4 @@ sources:
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 maintainers:
   - name: nimrodavni78
-appVersion: 0.1.0
+appVersion: 0.1.1

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -302,10 +302,9 @@ k8sCache:
     # -- K8s Cache image registry (defaults to docker.io)
     registry: "docker.io"
     # -- K8s Cache image repository.
-    # TODO remove k8s cache?
-    repository: grafana/beyla-k8s-cache
+    repository: otel/opentelemetry-ebpf-k8s-cache
     # -- (string) K8s Cache image tag. When empty, the Chart's appVersion is used.
-    tag: 2.2.4
+    tag: main
     # -- K8s Cache image's SHA256 digest (either in format "sha256:XYZ" or "XYZ"). When set, will override `image.tag`.
     digest: null
     # -- K8s Cache image pull policy.

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -313,7 +313,7 @@ k8sCache:
     pullSecrets: []
   service:
     # -- Name of both the Service and Deployment
-    name: otel-ebpf-k8s-cache
+    name: opentelemetry-ebpf-instrumentation-k8s-cache
     # -- Port of the Kubernetes metadata cache service.
     port: 50055
     # -- Service annotations.


### PR DESCRIPTION
after [this PR](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/131) was merged, we can use the offical otel image instead of the beyla one