### PR TITLE
[FEATURE] adding annotation discovery preset

### DIFF
--- a/charts/opentelemetry-collector/templates/NOTES.txt
+++ b/charts/opentelemetry-collector/templates/NOTES.txt
@@ -57,3 +57,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if and .Values.presets.logsCollection.enabled .Values.presets.annotationDiscovery.logs.enabled }}
+{{- fail "[ERROR] logsCollection and annotationDiscovery.logs are mutually exclusive" }}
+{{- end }}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -612,6 +612,7 @@ receivers:
       enabled: true
       default_annotations:
         io.opentelemetry.discovery.logs/enabled: true
+    receivers:
   {{- end }}
   {{- if .Values.presets.annotationDiscovery.metrics.enabled }}
   receiver_creator/metrics:
@@ -619,6 +620,7 @@ receivers:
       - k8s_observer
     discovery:
       enabled: true
+    receivers:
   {{- end }}
 {{- end }}
 

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -46,6 +46,9 @@ Build config file for daemonset OpenTelemetry Collector
 {{- if .Values.presets.logsCollection.enabled }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
+{{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled }}
+{{- $config = (include "opentelemetry-collector.applyAnnotationDiscoveryConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
 {{- if .Values.presets.profilesCollection.enabled }}
 {{- $config = (include "opentelemetry-collector.applyProfilesConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
@@ -150,6 +153,9 @@ Build config file for deployment OpenTelemetry Collector
 {{- $config := include "opentelemetry-collector.baseConfig" $data | fromYaml }}
 {{- if .Values.presets.logsCollection.enabled }}
 {{- $config = (include "opentelemetry-collector.applyLogsCollectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
+{{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled }}
+{{- $config = (include "opentelemetry-collector.applyAnnotationDiscoveryConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
 {{- if .Values.presets.mysql.metrics.enabled }}
 {{- $config = (include "opentelemetry-collector.applyMysqlConfig" (dict "Values" $data "config" $config) | fromYaml) }}
@@ -578,6 +584,44 @@ processors:
 {{- $config | toYaml }}
 {{- end }}
 
+{{- define "opentelemetry-collector.applyAnnotationDiscoveryConfig" -}}
+{{- $config := mustMergeOverwrite (include "opentelemetry-collector.annotationDiscoveryConfig" .Values | fromYaml) .config }}
+{{- $_ := set $config.service "extensions" (append $config.service.extensions "k8s_observer" | uniq) }}
+{{- if .Values.presets.annotationDiscovery.logs.enabled }}
+{{- $_ := set $config.service.pipelines "logs/discovery" (dict "receivers" (list "receiver_creator/logs") "processors" (list "memory_limiter") "exporters" (list)) }}
+{{- end }}
+{{- if .Values.presets.annotationDiscovery.metrics.enabled }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "receiver_creator/metrics" | uniq) }}
+{{- end }}
+{{- $config | toYaml }}
+{{- end }}
+
+{{- define "opentelemetry-collector.annotationDiscoveryConfig" -}}
+
+extensions:
+  k8s_observer:
+    auth_type: serviceAccount
+    node: ${env:K8S_NODE_NAME}
+
+receivers:
+  {{- if .Values.presets.annotationDiscovery.logs.enabled }}
+  receiver_creator/logs:
+    watch_observers:
+      - k8s_observer
+    discovery:
+      enabled: true
+      default_annotations:
+        io.opentelemetry.discovery.logs/enabled: true
+  {{- end }}
+  {{- if .Values.presets.annotationDiscovery.metrics.enabled }}
+  receiver_creator/metrics:
+    watch_observers:
+      - k8s_observer
+    discovery:
+      enabled: true
+  {{- end }}
+{{- end }}
+
 {{- define "opentelemetry-collector.applyProfilesConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.profilesCollectionConfig" .Values | fromYaml) .config }}
 {{- $config | toYaml }}
@@ -747,7 +791,6 @@ receivers:
       {{- .Values.presets.logsCollection.extraFilelogOperators | toYaml | nindent 6 }}
       {{- end }}
 {{- end }}
-
 
 {{- define "opentelemetry-collector.profilesCollectionConfig" -}}
 exporters:

--- a/charts/opentelemetry-collector/templates/_pod.tpl
+++ b/charts/opentelemetry-collector/templates/_pod.tpl
@@ -39,7 +39,7 @@ containers:
           fieldRef:
             fieldPath: metadata.name
       {{- end }}
-      {{- if or .Values.presets.k8sResourceAttributes.enabled (and .Values.presets.kubernetesAttributes.enabled (or (eq .Values.mode "daemonset") .Values.presets.kubernetesAttributes.nodeFilter.enabled)) }}
+      {{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled .Values.presets.k8sResourceAttributes.enabled (and .Values.presets.kubernetesAttributes.enabled (or (eq .Values.mode "daemonset") .Values.presets.kubernetesAttributes.nodeFilter.enabled)) }}
       - name: K8S_NODE_NAME
         valueFrom:
           fieldRef:
@@ -206,7 +206,7 @@ containers:
         subPath: {{ .subPath }}
         {{- end }}
       {{- end }}
-      {{- if .Values.presets.logsCollection.enabled }}
+      {{- if or .Values.presets.logsCollection.enabled .Values.presets.annotationDiscovery.logs.enabled }}
       {{- if .Values.isWindows }}
       - name: varlogpods
         mountPath: C:\var\log\pods
@@ -313,7 +313,7 @@ volumes:
     secret:
       secretName: {{ .secretName }}
   {{- end }}
-  {{- if .Values.presets.logsCollection.enabled }}
+  {{- if or .Values.presets.logsCollection.enabled .Values.presets.annotationDiscovery.logs.enabled }}
   {{- if .Values.isWindows }}
   - name: varlogpods
     hostPath:

--- a/charts/opentelemetry-collector/templates/clusterrole.yaml
+++ b/charts/opentelemetry-collector/templates/clusterrole.yaml
@@ -110,4 +110,17 @@ rules:
     - roles
     verbs: ["get", "list", "watch"]
   {{- end }}
+  {{- if or .Values.presets.annotationDiscovery.logs.enabled .Values.presets.annotationDiscovery.metrics.enabled }}
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/stats"]
+    verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  {{- end }}
 {{- end }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -475,6 +475,12 @@ presets:
     k8sNodeName:
       enabled: true
 
+  annotationDiscovery:
+    logs:
+      enabled: false
+    metrics:
+      enabled: false
+
 configMap:
   # Specifies whether a configMap should be created (true by default)
   create: true


### PR DESCRIPTION
This pull request introduces a new feature for annotation-based discovery of logs and metrics in the OpenTelemetry Collector Helm chart. It includes updates to configuration templates, role-based access controls, and default values to support this functionality.

### Annotation-based Discovery Enhancements:

* Added a new configuration block for annotation-based discovery of logs and metrics in `charts/opentelemetry-collector/templates/_config.tpl`. This includes defining `opentelemetry-collector.applyAnnotationDiscoveryConfig` and `opentelemetry-collector.annotationDiscoveryConfig` to handle pipelines, extensions, and receivers for discovery.
* Updated conditional logic in the `Build config file` sections to include annotation discovery configurations when enabled. [[1]](diffhunk://#diff-d3c8687b50b2f7b2ca10ff878367b16b76ead0cfdf62548091b5bcc507dc2d68R49-R51) [[2]](diffhunk://#diff-d3c8687b50b2f7b2ca10ff878367b16b76ead0cfdf62548091b5bcc507dc2d68R157-R159)

### Updates to Pod Configuration:

* Modified `charts/opentelemetry-collector/templates/_pod.tpl` to ensure environment variables, volumes, and mounts are correctly configured for annotation-based log discovery. [[1]](diffhunk://#diff-1814aec196d9921187bbcaf36ba08c861e8da5f3ee1cb821cf9a87bd19d5ae76L42-R42) [[2]](diffhunk://#diff-1814aec196d9921187bbcaf36ba08c861e8da5f3ee1cb821cf9a87bd19d5ae76L209-R209) [[3]](diffhunk://#diff-1814aec196d9921187bbcaf36ba08c861e8da5f3ee1cb821cf9a87bd19d5ae76L316-R316)

### Role-based Access Control Adjustments:

* Updated `charts/opentelemetry-collector/templates/clusterrole.yaml` to include permissions required for annotation-based discovery, such as access to pods, nodes, and metrics endpoints.

### Default Values Configuration:

* Added default values for annotation discovery in `charts/opentelemetry-collector/values.yaml`, with both logs and metrics discovery disabled by default.