### PR TITLE
Clarify otel-integration changelog procedure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,11 @@ These instructions apply to all development via the Codex web UI.
   3. Run `make generate-examples CHARTS=opentelemetry-collector` to regenerate example manifests.
   4. Commit the regenerated examples along with your other changes.
 
+### Updating Changelog
+- Add new entry to `charts/opentelemetry-collector/CHANGELOG.md`.
+- Use current date in YYYY-MM-DD format (get with `date +%Y-%m-%d`).
+- Copy the entries from the opentelemetry-collector changelog.
+- Follow the existing format: `### vX.Y.Z / YYYY-MM-DD`.
+
+Make sure to update the version only once to avoid duplicate changelog entries.
+


### PR DESCRIPTION
## Summary
- clarify how to update otel-integration changelog
- note to update the chart version only once to avoid duplicate entries

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_6863c484bea48322bb699b9d402bb2f3