### PR TITLE
Fix collector metrics preset

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry Collector
 
+### v0.118.7 / 2025-07-18
+- [Fix] Remove `without_units` from collector metrics preset
+
 ### v0.118.6 / 2025-07-18
 - [Fix] Skip prometheus receiver from collectorMetrics preset when PodMonitor or ServiceMonitor is enabled
 

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.118.6
+version: 0.118.7
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -123,4 +123,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e572f7d69b5f44430da19e7b0756c60e164fd961fc0c9c5af4a93207b782746d
+        checksum/config: 70ff6114cc5d44a9dfe05f2ee7c2a4a34c6d015e963acb6b1ed42dfbf3847753
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -122,4 +122,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 670d66dd0b32622d7414d808621f643f45ae072e32286841c067a1df560162af
+        checksum/config: 1ce6e6c3db41491378c8cc53e92cce5a83d90bbc531296d467aff6bf8b74c8cc
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -164,4 +164,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -163,4 +163,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8f12f19fe3b67cf1526a24038e3a94f46ada9f0e6b6fca102bb8efe726cabb87
+        checksum/config: 6a313f720370432bc9a66729698a5b95641fa47faa660683ba948f5eb08db2a4
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c1bbd0623f54cd664a228c9c43778ee6f546a78af4221b9c1239abc17fc5250
+        checksum/config: 3829edd212ae04d1aec96068191bad927d0bee806783b2d5a5d0cd26ff09aa0b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -161,4 +161,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd62bba3610345c5efabcc46d39351ddef6a4cfbb83a52b988064c4fe72ee394
+        checksum/config: e273d5f3cd91f7d903a5a32b53c31c3d365136fae670ec841d554bb53d5283f7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -96,4 +96,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 233d9ed0b850420b8e2079e1a62003c6c7d76dde4efc72b5bc4fb3ab1eac25dc
+        checksum/config: ede53b02af2845de44ce798b15619769e3d5b443b2ea8c8aff33594a8d48c35f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -87,4 +87,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e35e907785101f3b381003644d67c3664302dc044fd892f7f8abb3838face626
+        checksum/config: 27973ce0d10d8ba423c040c7b3dd85488cd428730a9ff9d3c16637c0a92c3f4e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/podmonitor.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/podmonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -526,7 +526,7 @@ data:
         logs:
           encoding: json
         resource:
-          helm.chart.opentelemetry-collector.version: 0.118.6
+          helm.chart.opentelemetry-collector.version: 0.118.7
           k8s.daemonset.name: example-opentelemetry-collector
           k8s.namespace.name: default
           k8s.node.name: ${env:KUBE_NODE_NAME}

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 997d5320fc35aa985dc15e1e0ab2cc3e153ea69a79ccc3aa07a3367c4e15e469
+        checksum/config: 1ad817e6a2f3defdaf2ea869045df4721dcb3294688988712ed74dcae468d397
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -536,4 +536,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-supervisor.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-supervisor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-supervisor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 70ac5cee4f4a46b52c5fc277793a0fd704f87b56269334243911a0488116d5da
+        checksum/config: 5bd1c861ef16bf53b6033444e43545de3d5922ca746b127c4a1457665b564109
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -100,4 +100,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31159d89534f42eaebdbdf39ef7bd63a2d0ea70c8cc1d1bef75453d540ef4dbc
+        checksum/config: 28ee1a3931b5458c53b6bb0c269900fae07e702beed7391fbddadfce5d4def99
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c6d5c3c1ccca060242f704bca006157301f014374111bf3eacd2e9192d93f7ab
+        checksum/config: afe3de86ec09529b80c9c4a47468212ef546a5dbdc0c404236f215b6da3f986b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector-target-allocator

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/podmonitor.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/podmonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -213,4 +213,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d1a7ab1f27d6a487423b8bbc72625e83c523700e2f989e5585069093dd1049c9
+        checksum/config: d7a4c650ef3d6e016c9ab355a13bc1b80711ce5e2a56ba53bf90448c517504e9
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -96,4 +96,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4dd324f490c5dde03ba187ca1d396317b6389665fac8738b2e9e34973e098ab9
+        checksum/config: daeae5f449951eed5a8bf900f3fe905002ccd975976b003cc83c0999c06c6ce3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/hpa.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -75,4 +75,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0ea7ecf21acf7371c5efaa59e38cf23ea20f3ddc41fe719a19562d68092b4f90
+        checksum/config: b79debc79b220011a6141a8ce226063d9d9e6695c2c0ce9aa24d7e1197f9d014
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -221,4 +221,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5c916a729818204485c7aadf5dacfb7118a8333498978461ebb8ecad1aaed547
+        checksum/config: cd7eb96d76dc3619a417e2b9436188420678f285e1a7d22989ca3fe39eda301e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -35,7 +35,7 @@ data:
             cx.agent.type: agent
             cx.cluster.name: test
             cx.integrationID: test
-            helm.chart.opentelemetry-collector.version: 0.118.6
+            helm.chart.opentelemetry-collector.version: 0.118.7
             service.name: opentelemetry-collector
         server:
           http:
@@ -236,4 +236,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dcf9084d41fd099698629ee7c398e50e8ea3c423237bb10842779a630697fac0
+        checksum/config: 4ef3c9cf7a193ade9d3847e17586eeabbdc24b6a1466ccf24773124519c4a690
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -151,4 +151,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a195f150693e7ac40b11d26973da97b8ff194ffcc8165f078e1baf3d6d7ff1b3
+        checksum/config: a4e7ce31aab50b5ae3902cf5902b1f454b689395ecbe9eb880b641f6631da1a5
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -120,4 +120,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9d2f41967860602354f7bb3a2be85c6d76f7ee28348929abd0c8767b760d06cf
+        checksum/config: 744581815974f9e6d882dfaf843772f821ca26311604118211848054e0414071
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -108,4 +108,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b0e2434781aae253712247f8bd5ec2a7807cf6d9b76a554e3bd904a7dcd0cb60
+        checksum/config: 55d3ea3c767b74a27ec9aa183170382714d2284db6374abca59190982bc82843
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -363,4 +363,3 @@ spec:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -439,4 +439,3 @@ spec:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -96,4 +96,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -116,4 +116,3 @@ spec:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-ds-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-ds-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -312,4 +312,3 @@ spec:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/profiles/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -127,4 +127,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/profiles/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 97491fdd0d694992f10c813641069f63f830f68167bad3d80a78f6bd8e28092f
+        checksum/config: 7799f886b5bbb613df299578a8ee1606b43622c7c243291e7c7113e2b760be03
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/profiles/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -253,4 +253,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9ea2eebaa56af1b76927e4e5c2f2f473e357e5d1f4308e3eff17c569faa90d04
+        checksum/config: 764536a3246fe3c3d68ccbd222a8693b88230e89c3f7977b5a3ab5ef2940ae78
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -166,4 +166,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9f82b5b6e8ae82525cba54a9723c0643d88cb3f586946ed50d5bb54aac4b77d0
+        checksum/config: 42cc23203cff7b18f9ee06c13aa64862590822918f51f6de11995bb7f5bfdc9b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/routing/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -188,4 +188,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dccd59baccaeb0aae03c68f7892a8f02f7fa1c7188ef1bea671d8d2aee14bcee
+        checksum/config: 79c943b440b31049c41dc374d05570fa38cbed62254ae65d779008be3b4d4fb7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -96,4 +96,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 52b8b0ebabde5444727bf1deebdc3161c46bc542d684008801ba67b0873c8719
+        checksum/config: 4b75431f6e5dd23e286b08e1126d0e3ab9512a46e175df89f64b1512a11b48ee
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/transactions/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/transactions/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -103,4 +103,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/transactions/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/transactions/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b9db01f5983118ae677588bb60039416e3bcec821fd2ce392e0b876af4ae6141
+        checksum/config: dc66a2162416b0bd538dd3f5428645b96b490dfaa243c1191e598fa53469a8ae
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/transactions/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/transactions/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -96,4 +96,3 @@ data:
                 prometheus:
                   host: ${env:MY_POD_IP}
                   port: 8888
-                  without_units: true

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4dd324f490c5dde03ba187ca1d396317b6389665fac8738b2e9e34973e098ab9
+        checksum/config: daeae5f449951eed5a8bf900f3fe905002ccd975976b003cc83c0999c06c6ce3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.118.6
+    helm.sh/chart: opentelemetry-collector-0.118.7
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.130.0"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2074,7 +2074,6 @@ service:
         - pull:
             exporter:
               prometheus:
-                without_units: true
                 host: {{ include "opentelemetry-collector.envHost" (dict "env" "MY_POD_IP" "context" $) }}
                 port: 8888
 {{- end }}


### PR DESCRIPTION
## Summary
- remove `without_units` from collector metrics preset
- bump chart version to 0.118.7
- regenerate examples

## Testing
- `make generate-examples CHARTS=opentelemetry-collector`
- `make check-examples CHARTS=opentelemetry-collector`

------
https://chatgpt.com/codex/tasks/task_b_687a329e8d5083228ce2a640ba5aaf4e