### PR TITLE
chore(makefile): generate and check examples concurrently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,101 @@
 TMP_DIRECTORY = ./tmp
 CHARTS ?= opentelemetry-collector opentelemetry-operator opentelemetry-demo opentelemetry-ebpf
+MAX_PARALLEL_EXAMPLES ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+# Reusable parallel execution with ordered logging utility
+define run_parallel_with_logging
+	RUNNING_JOBS=0; \
+	EXAMPLE_ORDER=""; \
+	mkdir -p $(TMP_DIRECTORY)/logs; \
+	for example in $(1); do \
+		while [ $$RUNNING_JOBS -ge $(MAX_PARALLEL_EXAMPLES) ]; do \
+			wait -n 2>/dev/null || true; \
+			RUNNING_JOBS=$$(($$RUNNING_JOBS - 1)); \
+		done; \
+		EXAMPLE_ORDER="$${EXAMPLE_ORDER} $${example}"; \
+		{ \
+			LOG_FILE="$(TMP_DIRECTORY)/logs/$(2)-$${example}.log"; \
+			{ $(3); } > "$${LOG_FILE}" 2>&1; \
+		} & \
+		RUNNING_JOBS=$$(($$RUNNING_JOBS + 1)); \
+	done; \
+	wait; \
+	for example in $${EXAMPLE_ORDER}; do \
+		LOG_FILE="$(TMP_DIRECTORY)/logs/$(2)-$${example}.log"; \
+		if [ -f "$${LOG_FILE}" ]; then \
+			cat "$${LOG_FILE}"; \
+			echo "--------------------------------"; \
+			rm -f "$${LOG_FILE}"; \
+		fi; \
+	done; \
+	rm -rf $(TMP_DIRECTORY)/logs
+endef
 
 .PHONY: generate-examples
 generate-examples:
 	for chart_name in $(CHARTS); do \
+		echo "Processing chart: $${chart_name} (max $(MAX_PARALLEL_EXAMPLES) parallel examples)"; \
 		EXAMPLES_DIR=charts/$${chart_name}/examples; \
 		EXAMPLES=$$(find $${EXAMPLES_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
-		for example in $${EXAMPLES}; do \
+		helm dependency build charts/$${chart_name}; \
+		$(call run_parallel_with_logging,$${EXAMPLES},$${chart_name}, \
+			echo "Generating example: $${example}"; \
 			VALUES=$$(find $${EXAMPLES_DIR}/$${example} -name *values.yaml); \
 			rm -rf "$${EXAMPLES_DIR}/$${example}/rendered"; \
 			for value in $${VALUES}; do \
-				helm dependency build charts/$${chart_name}; \
-				helm template example charts/$${chart_name} --namespace default --values $${value} --output-dir "$${EXAMPLES_DIR}/$${example}/rendered"; \
+				helm template example charts/$${chart_name} --namespace default --values $${value} --output-dir "$${EXAMPLES_DIR}/$${example}/rendered" | sed '/^$$/d'; \
 				mv $${EXAMPLES_DIR}/$${example}/rendered/$${chart_name}/templates/* "$${EXAMPLES_DIR}/$${example}/rendered"; \
 				SUBCHARTS_DIR=$${EXAMPLES_DIR}/$${example}/rendered/$${chart_name}/charts; \
-				SUBCHARTS=$$(find $${SUBCHARTS_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
-				for subchart in $${SUBCHARTS}; do \
-					mkdir -p "$${EXAMPLES_DIR}/$${example}/rendered/$${subchart}"; \
-					mv $${SUBCHARTS_DIR}/$${subchart}/templates/* "$${EXAMPLES_DIR}/$${example}/rendered/$${subchart}"; \
-				done; \
+				if [ -d "$${SUBCHARTS_DIR}" ]; then \
+					SUBCHARTS=$$(find $${SUBCHARTS_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \; 2>/dev/null || true); \
+					for subchart in $${SUBCHARTS}; do \
+						mkdir -p "$${EXAMPLES_DIR}/$${example}/rendered/$${subchart}"; \
+						mv $${SUBCHARTS_DIR}/$${subchart}/templates/* "$${EXAMPLES_DIR}/$${example}/rendered/$${subchart}" 2>/dev/null || true; \
+					done; \
+				fi; \
 				rm -rf $${EXAMPLES_DIR}/$${example}/rendered/$${chart_name}; \
 			done; \
-		done; \
+			printf "Completed example: $${example}\n" \
+		); \
+		echo "Completed chart: $${chart_name}"; \
 	done
 
 .PHONY: check-examples
 check-examples:
 	for chart_name in $(CHARTS); do \
+		echo "Checking chart: $${chart_name} (max $(MAX_PARALLEL_EXAMPLES) parallel examples)"; \
 		EXAMPLES_DIR=charts/$${chart_name}/examples; \
 		EXAMPLES=$$(find $${EXAMPLES_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
-		for example in $${EXAMPLES}; do \
+		helm dependency build charts/$${chart_name}; \
+		EXIT_CODE=0; \
+		$(call run_parallel_with_logging,$${EXAMPLES},$${chart_name}, \
 			echo "Checking example: $${example}"; \
+			EXAMPLE_TMP="${TMP_DIRECTORY}/check-$${chart_name}-$${example}"; \
 			VALUES=$$(find $${EXAMPLES_DIR}/$${example} -name *values.yaml); \
 			for value in $${VALUES}; do \
-				helm dependency build charts/$${chart_name}; \
-				helm template example charts/$${chart_name} --namespace default --values $${value} --output-dir "${TMP_DIRECTORY}/$${example}"; \
-				SUBCHARTS_DIR=${TMP_DIRECTORY}/$${example}/$${chart_name}/charts; \
-				SUBCHARTS=$$(find $${SUBCHARTS_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
-				for subchart in $${SUBCHARTS}; do \
-					mkdir -p "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates/$${subchart}"; \
-					mv ${TMP_DIRECTORY}/$${example}/$${chart_name}/charts/$${subchart}/templates/* "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates/$${subchart}"; \
-				done; \
+				helm template example charts/$${chart_name} --namespace default --values $${value} --output-dir "$${EXAMPLE_TMP}" | sed '/^$$/d'; \
+				SUBCHARTS_DIR=$${EXAMPLE_TMP}/$${chart_name}/charts; \
+				if [ -d "$${SUBCHARTS_DIR}" ]; then \
+					SUBCHARTS=$$(find $${SUBCHARTS_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \; 2>/dev/null || true); \
+					for subchart in $${SUBCHARTS}; do \
+						mkdir -p "$${EXAMPLE_TMP}/$${chart_name}/templates/$${subchart}"; \
+						mv $${SUBCHARTS_DIR}/$${subchart}/templates/* "$${EXAMPLE_TMP}/$${chart_name}/templates/$${subchart}" 2>/dev/null || true; \
+					done; \
+				fi; \
 			done; \
-			if diff -r "$${EXAMPLES_DIR}/$${example}/rendered" "${TMP_DIRECTORY}/$${example}/$${chart_name}/templates" > /dev/null; then \
-				echo "Passed $${example}"; \
+			if diff -r "$${EXAMPLES_DIR}/$${example}/rendered" "$${EXAMPLE_TMP}/$${chart_name}/templates" > /dev/null 2>&1; then \
+				printf "Passed $${example}\n"; \
 			else \
-				echo "Failed $${example}. run 'make generate-examples' to re-render the example with the latest $${example}/values.yaml"; \
-				rm -rf ${TMP_DIRECTORY}; \
-				exit 1; \
+				printf "Failed $${example}. run 'make generate-examples' to re-render the example with the latest $${example}/values.yaml\n"; \
+				EXIT_CODE=1; \
 			fi; \
-			rm -rf ${TMP_DIRECTORY}; \
-		done; \
+			rm -rf "$${EXAMPLE_TMP}" \
+		); \
+		if [ $$EXIT_CODE -ne 0 ]; then \
+			echo "Some examples failed for chart: $${chart_name}"; \
+			exit 1; \
+		fi; \
+		echo "All examples passed for chart: $${chart_name}"; \
 	done
 
 .PHONY: update-operator-crds


### PR DESCRIPTION
This PR makes the generate and check examples scripts generate/check examples concurrently. By default, it runs as much processes as there are CPU cores. As this is mostly I/O bound, it shouldn't spike CPU usage.

The output of each example's run is sent to a temporary folder, then later collected, and printed in order. The temporary folder is removed at the end.

This should make both tasks much faster in development and hopefully CI too.

<details><summary>Example output</summary>
<p>

```sh
$ time make generate-examples CHARTS=opentelemetry-collector
for chart_name in opentelemetry-collector; do \
                echo "Processing chart: ${chart_name} (max 12 parallel examples)"; \
                EXAMPLES_DIR=charts/${chart_name}/examples; \
                EXAMPLES=$(find ${EXAMPLES_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
                helm dependency build charts/${chart_name}; \
                        RUNNING_JOBS=0; EXAMPLE_ORDER=""; mkdir -p ./tmp/logs; for example in ${EXAMPLES}; do while [ $RUNNING_JOBS -ge 12 ]; do wait -n 2>/dev/null || true; RUNNING_JOBS=$(($RUNNING_JOBS - 1)); done; EXAMPLE_ORDER="${EXAMPLE_ORDER} ${example}"; { LOG_FILE="./tmp/logs/${chart_name}-${example}.log"; {  echo "Generating example: ${example}"; VALUES=$(find ${EXAMPLES_DIR}/${example} -name *values.yaml); rm -rf "${EXAMPLES_DIR}/${example}/rendered"; for value in ${VALUES}; do helm template example charts/${chart_name} --namespace default --values ${value} --output-dir "${EXAMPLES_DIR}/${example}/rendered" | sed '/^$/d'; mv ${EXAMPLES_DIR}/${example}/rendered/${chart_name}/templates/* "${EXAMPLES_DIR}/${example}/rendered"; SUBCHARTS_DIR=${EXAMPLES_DIR}/${example}/rendered/${chart_name}/charts; if [ -d "${SUBCHARTS_DIR}" ]; then SUBCHARTS=$(find ${SUBCHARTS_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \; 2>/dev/null || true); for subchart in ${SUBCHARTS}; do mkdir -p "${EXAMPLES_DIR}/${example}/rendered/${subchart}"; mv ${SUBCHARTS_DIR}/${subchart}/templates/* "${EXAMPLES_DIR}/${example}/rendered/${subchart}" 2>/dev/null || true; done; fi; rm -rf ${EXAMPLES_DIR}/${example}/rendered/${chart_name}; done; printf "Completed example: ${example}\n" ; } > "${LOG_FILE}" 2>&1; } & RUNNING_JOBS=$(($RUNNING_JOBS + 1)); done; wait; for example in ${EXAMPLE_ORDER}; do LOG_FILE="./tmp/logs/${chart_name}-${example}.log"; if [ -f "${LOG_FILE}" ]; then cat "${LOG_FILE}"; echo "--------------------------------"; rm -f "${LOG_FILE}"; fi; done; rm -rf ./tmp/logs; \
                echo "Completed chart: ${chart_name}"; \
        done
Processing chart: opentelemetry-collector (max 12 parallel examples)
Generating example: daemonset-and-deployment
Error: lstat /Users/douglas/code/opentelemetry-helm-charts/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered: no such file or directory
mv: rename charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/opentelemetry-collector/templates/* to charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered: No such file or directory
wrote charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: daemonset-and-deployment
--------------------------------
Generating example: using-GOMEMLIMIT
wrote charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: using-GOMEMLIMIT
--------------------------------
Generating example: coralogix-exporter-pipelines
wrote charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: coralogix-exporter-pipelines
--------------------------------
Generating example: host-entity
Error: lstat /Users/douglas/code/opentelemetry-helm-charts/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered: no such file or directory
mv: rename charts/opentelemetry-collector/examples/host-entity/rendered/opentelemetry-collector/templates/* to charts/opentelemetry-collector/examples/host-entity/rendered: No such file or directory
Completed example: host-entity
--------------------------------
Generating example: deployment-use-existing-configMap
wrote charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: deployment-use-existing-configMap
--------------------------------
Generating example: opentelemetrycollector-daemonset-crd
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetry-collector/templates/opentelemetrycollector.yaml
Completed example: opentelemetrycollector-daemonset-crd
--------------------------------
Generating example: daemonset-supervisor
wrote charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/opentelemetry-collector/templates/configmap-supervisor.yaml
wrote charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: daemonset-supervisor
--------------------------------
Generating example: daemonset-only
wrote charts/opentelemetry-collector/examples/daemonset-only/rendered/opentelemetry-collector/templates/priorityclass.yaml
wrote charts/opentelemetry-collector/examples/daemonset-only/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-only/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-only/rendered/opentelemetry-collector/templates/daemonset.yaml
wrote charts/opentelemetry-collector/examples/daemonset-only/rendered/opentelemetry-collector/templates/podmonitor.yaml
Completed example: daemonset-only
--------------------------------
Generating example: opentelemetrycollector-crd
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetry-collector/templates/serviceaccount-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetry-collector/templates/clusterrole-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetry-collector/templates/clusterrolebinding-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetry-collector/templates/integrations/mysql/opentelemetrycollector-sidecar.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetry-collector/templates/opentelemetrycollector.yaml
Completed example: opentelemetrycollector-crd
--------------------------------
Generating example: gke-autopilot
wrote charts/opentelemetry-collector/examples/gke-autopilot/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/gke-autopilot/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/gke-autopilot/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/gke-autopilot/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/gke-autopilot/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/gke-autopilot/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: gke-autopilot
--------------------------------
Generating example: loadbalancing
wrote charts/opentelemetry-collector/examples/loadbalancing/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/loadbalancing/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/loadbalancing/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/loadbalancing/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: loadbalancing
--------------------------------
Generating example: deployment-only
wrote charts/opentelemetry-collector/examples/deployment-only/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/deployment-only/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/deployment-only/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/deployment-only/rendered/opentelemetry-collector/templates/deployment.yaml
wrote charts/opentelemetry-collector/examples/deployment-only/rendered/opentelemetry-collector/templates/hpa.yaml
Completed example: deployment-only
--------------------------------
Generating example: coralogix-exporter-pipeline
wrote charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: coralogix-exporter-pipeline
--------------------------------
Generating example: daemonset-reduced-attributes
wrote charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: daemonset-reduced-attributes
--------------------------------
Generating example: spanmetrics-multiple-preset
wrote charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: spanmetrics-multiple-preset
--------------------------------
Generating example: transactions
wrote charts/opentelemetry-collector/examples/transactions/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/transactions/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/transactions/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: transactions
--------------------------------
Generating example: daemonset-hostmetrics
wrote charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: daemonset-hostmetrics
--------------------------------
Generating example: opentelemetrycollector-deployment-crd
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/opentelemetry-collector/templates/opentelemetrycollector.yaml
Completed example: opentelemetrycollector-deployment-crd
--------------------------------
Generating example: daemonset-lifecycle-hooks
wrote charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: daemonset-lifecycle-hooks
--------------------------------
Generating example: daemonset-presets
wrote charts/opentelemetry-collector/examples/daemonset-presets/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-presets/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-presets/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/daemonset-presets/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/daemonset-presets/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: daemonset-presets
--------------------------------
Generating example: daemonset-windows
wrote charts/opentelemetry-collector/examples/daemonset-windows/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-windows/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-windows/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: daemonset-windows
--------------------------------
Generating example: statefulset-only
wrote charts/opentelemetry-collector/examples/statefulset-only/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/statefulset-only/rendered/opentelemetry-collector/templates/configmap-statefulset.yaml
wrote charts/opentelemetry-collector/examples/statefulset-only/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/statefulset-only/rendered/opentelemetry-collector/templates/statefulset.yaml
Completed example: statefulset-only
--------------------------------
Generating example: opentelemetrycollector-ds-crd
wrote charts/opentelemetry-collector/examples/opentelemetrycollector-ds-crd/rendered/opentelemetry-collector/templates/opentelemetrycollector.yaml
Completed example: opentelemetrycollector-ds-crd
--------------------------------
Generating example: resource-catalog
wrote charts/opentelemetry-collector/examples/resource-catalog/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/resource-catalog/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/resource-catalog/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/resource-catalog/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/resource-catalog/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/resource-catalog/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: resource-catalog
--------------------------------
Generating example: routing
wrote charts/opentelemetry-collector/examples/routing/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/routing/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/routing/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/routing/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/routing/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/routing/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: routing
--------------------------------
Generating example: profiles
wrote charts/opentelemetry-collector/examples/profiles/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/profiles/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/profiles/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/profiles/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/profiles/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: profiles
--------------------------------
Generating example: networkmode-ipv6
wrote charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/opentelemetry-collector/templates/daemonset.yaml
Completed example: networkmode-ipv6
--------------------------------
Generating example: daemonset-targetallocator
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/priorityclass.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/serviceaccount-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/configmap-agent.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/configmap-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/clusterrole-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/clusterrolebinding-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/service-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/daemonset.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/deployment-targetallocator.yaml
wrote charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/opentelemetry-collector/templates/podmonitor.yaml
Completed example: daemonset-targetallocator
--------------------------------
Generating example: kubernetesAttributes
wrote charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/opentelemetry-collector/templates/clusterrole.yaml
wrote charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/opentelemetry-collector/templates/clusterrolebinding.yaml
wrote charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: kubernetesAttributes
--------------------------------
Generating example: deployment-otlp-traces
wrote charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/deployment-otlp-traces/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: deployment-otlp-traces
--------------------------------
Generating example: metadata
wrote charts/opentelemetry-collector/examples/metadata/rendered/opentelemetry-collector/templates/serviceaccount.yaml
wrote charts/opentelemetry-collector/examples/metadata/rendered/opentelemetry-collector/templates/configmap.yaml
wrote charts/opentelemetry-collector/examples/metadata/rendered/opentelemetry-collector/templates/service.yaml
wrote charts/opentelemetry-collector/examples/metadata/rendered/opentelemetry-collector/templates/deployment.yaml
Completed example: metadata
--------------------------------
Completed chart: opentelemetry-collector
make generate-examples CHARTS=opentelemetry-collector  5.28s user 1.47s system 738% cpu 0.914 total
```

</p>
</details> 