### PR TITLE
Use debug exporter in gke-autopilot example

### DIFF
--- a/charts/opentelemetry-collector/examples/gke-autopilot/daemonset-values.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/daemonset-values.yaml
@@ -37,15 +37,15 @@ config:
       logs:
         exporters:
          - otlp
-         - logging
+         - debug
       metrics:
         exporters:
          - otlp
-         - logging
+         - debug
       traces:
         exporters:
          - otlp
-         - logging
+         - debug
 
 resources:
   limits:

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -216,7 +216,7 @@ data:
         logs:
           exporters:
           - otlp
-          - logging
+          - debug
           processors:
           - memory_limiter
           receivers:
@@ -225,7 +225,7 @@ data:
         metrics:
           exporters:
           - otlp
-          - logging
+          - debug
           processors:
           - memory_limiter
           - transform/kubeletstatscpu
@@ -237,7 +237,7 @@ data:
         traces:
           exporters:
           - otlp
-          - logging
+          - debug
           processors:
           - memory_limiter
           receivers:

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 56f6f51bd90c4460795723d0df52c03737dd80bd9618858de7a5cb1368220abc
+        checksum/config: 17b156ea5186dd636866639ff600f33fa5d7688d915edf78a7d6576cdf7c4c87
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector


### PR DESCRIPTION
## Summary
- use debug exporter instead of logging in gke-autopilot example
- regenerate example manifests

Ref: ES-726
## Testing
- `make generate-examples CHARTS=opentelemetry-collector`
- `make check-examples CHARTS=opentelemetry-collector`


------
https://chatgpt.com/codex/tasks/task_b_689c7e9472fc8322897f5cd252c81c94