### PR TITLE
Fix kubernetesAttributes example configuration

### DIFF
--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -164,10 +164,9 @@ data:
           exporters:
           - debug
           processors:
-          - resource
+          - memory_limiter
           - k8sattributes
           - transform/k8s_attributes
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a5bd2a611e300770beb36f007f8729549c9fd2a79c23e70c46f12e7b9d579591
+        checksum/config: 3ac7499f0ac0b0f89d4bb12acc88c9d18cf09d229ae2442ac823c8bbf8ef2ceb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/values.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/values.yaml
@@ -4,12 +4,3 @@ presets:
   kubernetesAttributes:
     enabled: true
 
-config:
-  service:
-    pipelines:      
-      traces:
-        processors:
-          - resource
-          - k8sattributes
-          - batch
-      


### PR DESCRIPTION
## Summary
- remove undefined resource processor from kubernetesAttributes example values
- regenerate examples for kubernetesAttributes to match updated config

## Testing
- `make generate-examples CHARTS=opentelemetry-collector`
- `./charts/opentelemetry-collector/validate-configs.sh` *(fails: Failed to download collector)*

------
https://chatgpt.com/codex/tasks/task_b_689d7906395483229b6e72e3027a7bc7