### PR TITLE
Feature/improve profiling service name

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry Collector
 
+### v0.119.10 / 2025-09-01
+- [Feat] Profiling: improve service name detection by otel conventions.
+
 ### v0.119.9 / 2025-08-28
 - [Feat] Add support for EKS Fargate.
 - [Feat] Added `eks` as detector to `resourcedetection/region` config.

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.119.9
+version: 0.119.10
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -853,17 +853,40 @@ processors:
 processors:
   transform/profiles:
     profile_statements:
+    # prioritized by
+    # https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#how-servicename-should-be-calculated
+      - set(resource.attributes["service.name"], resource.attributes["service.name"])
+        where resource.attributes["service.name"] != nil
+
+      - set(resource.attributes["service.name"], resource.attributes["k8s.label.instance"])
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.instance"] != nil
+
+      - set(resource.attributes["service.name"], resource.attributes["k8s.label.name"])
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.name"] != nil
+
       - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"])
-        where resource.attributes["k8s.deployment.name"] != nil
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"] != nil
+
+      - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"])
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"] != nil
 
       - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"])
-        where resource.attributes["k8s.statefulset.name"] != nil
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil
 
       - set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"])
-        where resource.attributes["k8s.daemonset.name"] != nil
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.daemonset.name"] != nil
 
       - set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"])
-        where resource.attributes["k8s.cronjob.name"] != nil
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.cronjob.name"] != nil
+
+      - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"])
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"] != nil
+
+      - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"])
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"] != nil
+
+      - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"])
+        where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"] != nil
 
   k8sattributes/profiles:
     extract:
@@ -878,6 +901,14 @@ processors:
         - k8s.pod.name
         - k8s.node.name
         - container.id
+      labels:
+        - tag_name: k8s.label.name
+          key: app.kubernetes.io/name
+          from: pod
+        - tag_name: k8s.label.instance
+          key: app.kubernetes.io/instance
+          from: pod
+        otel_annotations: true
 
     passthrough: false
     pod_association:


### PR DESCRIPTION
Improve service name detection in profiling preset
make sure to follow:
https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#how-servicename-should-be-calculated
in the future we might also want to allow users to configure their own priority with adding specific labels or annotations to detect service name, in our case we might want to use CX_SERVICE_NAME or something