### PR TITLE
opentelemetry-collector: validate rendered examples in collector CI

### DIFF
--- a/.github/workflows/validate-collector.yaml
+++ b/.github/workflows/validate-collector.yaml
@@ -2,7 +2,12 @@ name: Validate OpenTelemetry Collector Configurations
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
+      - '.github/actions/setup/**'
+      - '.github/workflows/validate-collector.yaml'
+      - 'Makefile'
       - 'charts/opentelemetry-collector/**'
   workflow_dispatch:
 
@@ -15,6 +20,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          create-kind-cluster: "false"
+
       - name: Validate OpenTelemetry Collector configurations
         run: make validate-examples
-        working-directory: .
+
+      - name: Check rendered OpenTelemetry Collector examples
+        run: make check-examples CHARTS=opentelemetry-collector

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ MAX_PARALLEL_EXAMPLES ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/n
 # Reusable parallel execution with ordered logging utility
 define run_parallel_with_logging
 	RUNNING_JOBS=0; \
+	FAILED=0; \
 	EXAMPLE_ORDER=""; \
 	mkdir -p $(TMP_DIRECTORY)/logs; \
 	for example in $(1); do \
 		while [ $$RUNNING_JOBS -ge $(MAX_PARALLEL_EXAMPLES) ]; do \
-			wait -n 2>/dev/null || true; \
+			if ! wait -n 2>/dev/null; then \
+				FAILED=1; \
+			fi; \
 			RUNNING_JOBS=$$(($$RUNNING_JOBS - 1)); \
 		done; \
 		EXAMPLE_ORDER="$${EXAMPLE_ORDER} $${example}"; \
@@ -19,7 +22,12 @@ define run_parallel_with_logging
 		} & \
 		RUNNING_JOBS=$$(($$RUNNING_JOBS + 1)); \
 	done; \
-	wait; \
+	while [ $$RUNNING_JOBS -gt 0 ]; do \
+		if ! wait -n 2>/dev/null; then \
+			FAILED=1; \
+		fi; \
+		RUNNING_JOBS=$$(($$RUNNING_JOBS - 1)); \
+	done; \
 	for example in $${EXAMPLE_ORDER}; do \
 		LOG_FILE="$(TMP_DIRECTORY)/logs/$(2)-$${example}.log"; \
 		if [ -f "$${LOG_FILE}" ]; then \
@@ -28,7 +36,8 @@ define run_parallel_with_logging
 			rm -f "$${LOG_FILE}"; \
 		fi; \
 	done; \
-	rm -rf $(TMP_DIRECTORY)/logs
+	rm -rf $(TMP_DIRECTORY)/logs; \
+	test $$FAILED -eq 0
 endef
 
 .PHONY: generate-examples
@@ -68,7 +77,6 @@ check-examples:
 		EXAMPLES_DIR=charts/$${chart_name}/examples; \
 		EXAMPLES=$$(find $${EXAMPLES_DIR} -type d -maxdepth 1 -mindepth 1 -exec basename \{\} \;); \
 		helm dependency build charts/$${chart_name}; \
-		EXIT_CODE=0; \
 		$(call run_parallel_with_logging,$${EXAMPLES},$${chart_name}, \
 			echo "Checking example: $${example}"; \
 			EXAMPLE_TMP="${TMP_DIRECTORY}/check-$${chart_name}-$${example}"; \
@@ -88,14 +96,10 @@ check-examples:
 				printf "Passed $${example}\n"; \
 			else \
 				printf "Failed $${example}. run 'make generate-examples' to re-render the example with the latest $${example}/values.yaml\n"; \
-				EXIT_CODE=1; \
+				exit 1; \
 			fi; \
 			rm -rf "$${EXAMPLE_TMP}" \
 		); \
-		if [ $$EXIT_CODE -ne 0 ]; then \
-			echo "Some examples failed for chart: $${chart_name}"; \
-			exit 1; \
-		fi; \
 		echo "All examples passed for chart: $${chart_name}"; \
 	done
 

--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### v0.130.2 / 2026-03-12
 
 - [Fix] Pass `command.extraArgs` to the managed Collector through the supervisor `agent.args` configuration instead of appending them to the `opampsupervisor` container command.
+- [Fix] Preserve `telemetry.sdk.*` resource attributes on traces when `reduceResourceAttributes` is enabled in provider-based mode, while continuing to remove them for logs and metrics.
 
 ### v0.130.1 / 2026-03-12
 

--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -42,7 +42,6 @@
 ### v0.130.2 / 2026-03-12
 
 - [Fix] Pass `command.extraArgs` to the managed Collector through the supervisor `agent.args` configuration instead of appending them to the `opampsupervisor` container command.
-- [Fix] Preserve `telemetry.sdk.*` resource attributes on traces when `reduceResourceAttributes` is enabled in provider-based mode, while continuing to remove them for logs and metrics.
 
 ### v0.130.1 / 2026-03-12
 


### PR DESCRIPTION
## Summary
- run collector config validation and rendered example checks in the collector-specific workflow
- fix `make check-examples` so parallel example failures return a non-zero exit code
- refresh the `daemonset-and-deployment` rendered example output that the new check surfaced as stale

## Testing
- make validate-examples
- make check-examples CHARTS=opentelemetry-collector