### PR TITLE
opentelemetry-collector: bump chart to v0.131.1 and lock ebpfProfiler default image tag

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## OpenTelemetry Collector
 
-### v0.131.2 / 2026-04-30
-
-- [Fix] Revert the eBPF profiler default image tag pin so eBPF profiler images follow the chart `appVersion` by default again.
-
-### v0.131.1 / 2026-04-30
-
-- [Fix] Keep the `opentelemetry-collector-ebpf-profiler` distribution on image tag `0.147.0` by default when the `ebpfProfiler` preset is enabled, while allowing `image.tag` overrides.
-
 ### v0.131.0 / 2026-04-30
 
 - [Feat] Bump OpenTelemetry Collector image to v0.151.0.

--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## OpenTelemetry Collector
 
+### v0.131.1 / 2026-04-30
+
+- [Fix] Keep the `opentelemetry-collector-ebpf-profiler` distribution on image tag `0.147.0` by default when the `ebpfProfiler` preset is enabled, while allowing `image.tag` overrides.
+
+### v0.131.0 / 2026-04-30
+
+- [Feat] Bump OpenTelemetry Collector image to v0.151.0.
+
 ### v0.130.18 / 2026-04-30
 
 - [Fix] Exclude `BOOKMARK` and `ERROR` watch event types from the `k8sobjects/resource_catalog` watch receivers used by the Kubernetes resource catalog presets, reducing non-actionable watch stream noise while preserving normal watch recovery behavior.

--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry Collector
 
+### v0.131.2 / 2026-04-30
+
+- [Fix] Revert the eBPF profiler default image tag pin so eBPF profiler images follow the chart `appVersion` by default again.
+
 ### v0.131.1 / 2026-04-30
 
 - [Fix] Keep the `opentelemetry-collector-ebpf-profiler` distribution on image tag `0.147.0` by default when the `ebpfProfiler` preset is enabled, while allowing `image.tag` overrides.

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.131.1
+version: 0.131.2
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.130.18
+version: 0.131.1
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -12,4 +12,4 @@ sources:
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 maintainers:
   - name: povilasv
-appVersion: 0.147.0
+appVersion: 0.151.0

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.131.2
+version: 0.131.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/templates/_custom_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_custom_helpers.tpl
@@ -91,6 +91,9 @@ Determine the container image to use based on presets and user overrides.
 {{- define "opentelemetry-collector.image" }}
 {{- $imageRepository := "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" }}
 {{- $imageTag := .Chart.AppVersion }}
+{{- if .Values.presets.ebpfProfiler.enabled }}
+{{- $imageTag = "0.147.0" }}
+{{- end }}
 {{- if (and (.Values.presets.ebpfProfiler.enabled) (.Values.presets.fleetManagement.enabled) (.Values.presets.fleetManagement.supervisor.enabled) (not .Values.collectorCRD.generate)) }}
 {{- $imageRepository = "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-ebpf-profiler" }}
 {{- else if (and (.Values.presets.fleetManagement.enabled) (.Values.presets.fleetManagement.supervisor.enabled) (not .Values.collectorCRD.generate)) }}

--- a/charts/opentelemetry-collector/templates/_custom_helpers.tpl
+++ b/charts/opentelemetry-collector/templates/_custom_helpers.tpl
@@ -91,9 +91,6 @@ Determine the container image to use based on presets and user overrides.
 {{- define "opentelemetry-collector.image" }}
 {{- $imageRepository := "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" }}
 {{- $imageTag := .Chart.AppVersion }}
-{{- if .Values.presets.ebpfProfiler.enabled }}
-{{- $imageTag = "0.147.0" }}
-{{- end }}
 {{- if (and (.Values.presets.ebpfProfiler.enabled) (.Values.presets.fleetManagement.enabled) (.Values.presets.fleetManagement.supervisor.enabled) (not .Values.collectorCRD.generate)) }}
 {{- $imageRepository = "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-ebpf-profiler" }}
 {{- else if (and (.Values.presets.fleetManagement.enabled) (.Values.presets.fleetManagement.supervisor.enabled) (not .Values.collectorCRD.generate)) }}


### PR DESCRIPTION
### Motivation

- Bump the Helm chart and collector app version to pick up new collector releases and record the changes in the changelog. 
- Ensure the `ebpfProfiler` preset uses a specific, known-safe image tag by default while still allowing user overrides via `image.tag`.

### Description

- Updated `Chart.yaml` to `version: 0.131.1` and `appVersion: 0.151.0`.
- Added `v0.131.1` and `v0.131.0` entries to `CHANGELOG.md` noting the `ebpfProfiler` image tag behavior and the app bump.
- Modified `templates/_custom_helpers.tpl` in the `opentelemetry-collector.image` helper to set the default `$imageTag` to `"0.147.0"` when `.Values.presets.ebpfProfiler.enabled`, while keeping the existing repository selection logic and allowing `image.tag` and `image.digest` to override.

### Testing

- Ran `helm lint` against the chart and it succeeded.
- Rendered templates with `helm template` for an installation with `.Values.presets.ebpfProfiler.enabled = true` and verified the image tag defaults to `0.147.0`.
- Rendered templates with an explicit `image.tag` override and verified the override was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f349f28d9c83228b59e4e9866c9f75)