### PR TITLE
opentelemetry-collector: bump chart to v0.131.0 and appVersion to v0.151.0

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry Collector
 
+### v0.131.0 / 2026-04-30
+
+- [Feat] Bump OpenTelemetry Collector image to v0.151.0.
+
 ### v0.130.18 / 2026-04-30
 
 - [Fix] Exclude `BOOKMARK` and `ERROR` watch event types from the `k8sobjects/resource_catalog` watch receivers used by the Kubernetes resource catalog presets, reducing non-actionable watch stream noise while preserving normal watch recovery behavior.

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.130.18
+version: 0.131.0
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -12,4 +12,4 @@ sources:
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 maintainers:
   - name: povilasv
-appVersion: 0.147.0
+appVersion: 0.151.0


### PR DESCRIPTION
### Motivation
- Bump the Helm chart to publish a release that uses the newer OpenTelemetry Collector image `v0.151.0` and record the change in the changelog.

### Description
- Update `Chart.yaml` to `version: 0.131.0` and `appVersion: 0.151.0` and add a `v0.131.0` entry to `CHANGELOG.md` describing the image bump.

### Testing
- No automated tests were run for this chart-only metadata change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f349f28d9c83228b59e4e9866c9f75)