### PR TITLE
feat: add to spanMetricsMulti same parameters as for spanMetrics

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.131.5 / 2026-05-18
 
-- [Feat] Add `transformStatements`, `spanNameReplacePattern`, `dbMetrics`, and `compactMetrics` options to the `spanMetricsMulti` preset, matching the single `spanMetrics` preset capabilities.
+- [Feat] Add optional `transformStatements`, `spanNameReplacePattern`, `dbMetrics`, and `compactMetrics` to the `spanMetricsMulti` preset, matching the single `spanMetrics` preset capabilities. All are opt-in (`dbMetrics` / `compactMetrics` default to off; dimension helpers preserve prior `spanMetricsMulti` behavior unless explicitly configured).
 
 ### v0.131.4 / 2026-05-13
 

--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry Collector
 
+### v0.131.5 / 2026-05-18
+
+- [Feat] Add `transformStatements`, `spanNameReplacePattern`, `dbMetrics`, and `compactMetrics` options to the `spanMetricsMulti` preset, matching the single `spanMetrics` preset capabilities.
+
 ### v0.131.4 / 2026-05-13
 
 - [Feat] Unify versioning of all Supervisor-based images and control it from `presets.fleetManagement.supervisor.imageVersion`. Top-level `image.tag` overrides has priority over this.

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.131.4
+version: 0.131.5
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/ci/preset-spanMetricsMultiExtras-values.yaml
+++ b/charts/opentelemetry-collector/ci/preset-spanMetricsMultiExtras-values.yaml
@@ -1,0 +1,30 @@
+mode: daemonset
+
+presets:
+  batch:
+    enabled: true
+  spanMetricsMulti:
+    enabled: true
+    transformStatements:
+      - set(attributes["custom"], true)
+    spanNameReplacePattern:
+      - regex: "/[0-9a-f-]{36}"
+        replacement: "/?"
+    dbMetrics:
+      enabled: true
+      transformStatements:
+        - set(attributes["db.custom"], true)
+      compactMetrics:
+        enabled: true
+    compactMetrics:
+      enabled: true
+    configs:
+      - selector: route() where attributes["service.name"] == "one"
+        histogramBuckets: [1s, 2s]
+      - selector: route() where attributes["service.name"] == "two"
+        histogramBuckets: [5s, 10s]
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 200M

--- a/charts/opentelemetry-collector/examples/additional-endpoints/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/additional-endpoints/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -311,7 +311,7 @@ data:
         agent_description:
           include_resource_attributes: true
           non_identifying_attributes:
-            helm.chart.opentelemetry-collector.version: 0.131.4
+            helm.chart.opentelemetry-collector.version: 0.131.5
         server:
           http:
             endpoint: https://ingress.coralogix.com/opamp/v1
@@ -322,7 +322,7 @@ data:
         agent_description:
           include_resource_attributes: true
           non_identifying_attributes:
-            helm.chart.opentelemetry-collector.version: 0.131.4
+            helm.chart.opentelemetry-collector.version: 0.131.5
         server:
           http:
             endpoint: https://ingress.coralogixsg.com/opamp/v1
@@ -333,7 +333,7 @@ data:
         agent_description:
           include_resource_attributes: true
           non_identifying_attributes:
-            helm.chart.opentelemetry-collector.version: 0.131.4
+            helm.chart.opentelemetry-collector.version: 0.131.5
         server:
           http:
             endpoint: https://ingress.eu2.coralogix.com/opamp/v1
@@ -344,7 +344,7 @@ data:
         agent_description:
           include_resource_attributes: true
           non_identifying_attributes:
-            helm.chart.opentelemetry-collector.version: 0.131.4
+            helm.chart.opentelemetry-collector.version: 0.131.5
         server:
           http:
             endpoint: https://ingress.private.coralogix.com/opamp/v1

--- a/charts/opentelemetry-collector/examples/additional-endpoints/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/additional-endpoints/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a47eaea16c3c5158cbbd2cf52df8e8acfe06ba4e9c6666255b5aa55dadf446b8
+        checksum/config: d87d14b51c660a5e5404441e8f56ffa77419e44112f8f45b3400c888a89dc314
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/additional-endpoints/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/additional-endpoints/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5e49b4cec873b41b36e75dfa107f3bcfbee6eeaef58a42d2cad207c2ad883bb0
+        checksum/config: 9adf55919117e86bf2ab5949939516ce9eb6bc71364f524d7a20aa144db43eea
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/aws-eks-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-helper/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-helper/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-helper/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-helper/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a832fd2aed003bbc621f434cc2c826dc866dd02570e2b9a3bd1cf899bb0eeee2
+        checksum/config: 1cb3ad806a00f7f8bf5132ff3b269dc9b1b8e80da5cea6d469508a77308c236d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-helper/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-helper/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-keepalive/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-keepalive/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-keepalive/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-keepalive/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c0ab07f7c034229a0b2dc36197dd8da580433459709f90b4bc4a83b6321e6ff9
+        checksum/config: bc947e6a16a12b4f99180c216a018ec03900ce551061cf145203e60b670a05cb
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-keepalive/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-keepalive/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f3a9bf5b8c23bc1ca43495688226afbc6cabe977651c88ea524665a0a73cd062
+        checksum/config: 042cd187f4ec919f940cab30a7730b62e6bfde891fd287436af9d94746734c6c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipeline/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 61e47fbc3029c61ed06cd9c0d8d0af8101bbd9feac3acbd0b05ba387c254d2e9
+        checksum/config: 8ee84c71b117ff5be151e0da4670170bf4a079444907922960aa0ecdf581e3b8
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/coralogix-exporter-pipelines/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8110804c454412498bc4542d5a5411a816c6bf2ca3eaac9c20db30a73d59adf7
+        checksum/config: d5decf701bba539ef1e6fb7d2a599d974cb29866ed6c71188172c16c5be55bf0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c2d09b77741b8a47ff4188abc5c3fd43dade92c9f02a28ca22b1f0a5e021998
+        checksum/config: fe75fe441a634115af0b39c76bbb3653b4f49840e1c7fff032da519367536e2d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-and-deployment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f44500353780c42bf87ee5e5f530f5f036e07f39b823bae53d571187fca32959
+        checksum/config: 37e8c063b8a79159c24d2ab37675f8eadd9313ebfb87954266d8b89d819fd126
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-apiserver-metrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-deltatocumulative-defaults/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-deltatocumulative-defaults/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-deltatocumulative-defaults/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-deltatocumulative-defaults/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6565fbd9716f098810193d388d8a2e0c4bc870869d010be2f3dfe1d5f9be8410
+        checksum/config: 0b7dbc6819705721e0b5ec5d44c415265a473c473ee21ecf4a69813986fc5acf
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-deltatocumulative-defaults/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-deltatocumulative-defaults/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-deltatocumulative/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-deltatocumulative/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-deltatocumulative/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-deltatocumulative/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cdbd7caeddbf207198eaa78a7e9769bd0617f58646c1b8d634ab45071e572aa7
+        checksum/config: d75d92771ccc956e26b98b5b62ad8177c7d1e338cb8b95b11d03f856c63ec747
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-deltatocumulative/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-deltatocumulative/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1fad446ad23d01aef9b5326f3a23e36f6506983ea593f7d0b1e7a812852da41c
+        checksum/config: 182ace6ac0aa56027e5cbe62604f166c42cbaae828a9c736e1d76d37f7fe2c14
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-hostmetrics/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 58e4db7ed98400004e7808f03e2e0988a6c3df73f71d7795f825511e6362ffd7
+        checksum/config: 329ffa6d728754fd461db7ce5debbaa8febca81e57a1d37c0a01288ca4dff3af
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-lifecycle-hooks/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 92eb7c7815d2f40a00cd9b2acf5a8e544bc2032ebfd4e1b69766e1eb11f07c68
+        checksum/config: e5d76ea46d792a02d764f30e13d7e37650abb50abc37772884d73bee3ffd6bda
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/podmonitor.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/podmonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d30f770171899d4a7fbf4876ad35e1c6dc7d2d616ad780843c6b2079e096d922
+        checksum/config: 3c3a5922eed315aec01880a0fe567a6705598536d1b6142b39768533b8f48d16
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-presets/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6b607c3b03f64f9dc557f48ecc115327a4260ef1560866e143c140848f7c68a0
+        checksum/config: a8e3c714964ce888edd85810b617f746c7e3eef48a27357a3b584e241abd991f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-reduced-attributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/configmap-supervisor.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/configmap-supervisor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-supervisor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d79040e53d0908cc4b092dd47560be414c578cdde10fc0e6618d7daea6af9a02
+        checksum/config: 4818ba782f89447a2834a1a63b38fa37d321573bb43ecee16b1d0f8bb099af2b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor-image-version/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-supervisor.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/configmap-supervisor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-supervisor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d79040e53d0908cc4b092dd47560be414c578cdde10fc0e6618d7daea6af9a02
+        checksum/config: 4818ba782f89447a2834a1a63b38fa37d321573bb43ecee16b1d0f8bb099af2b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-supervisor/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/configmap-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 884a2aaeab505f5cae8383f3415b11732835f70b8aaedaccac366023ba6a5b24
+        checksum/config: fc1be28fb27aa6696e8699b797d2a9587cb947ad56c92eadd02526d15043b870
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/deployment-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dc133efa9ae8ad822abfc17173d332f457e67b59bba2e919be75561ea8435d3c
+        checksum/config: 220507a657c70357591696681477b4840452692809668ccd71315c487218be74
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector-target-allocator

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/podmonitor.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/podmonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/service-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-targetallocator/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c583f6b87ddda29e92f384d513c27cd5af8c7f58999028d48393eb3fc968cdbf
+        checksum/config: b2bf10437557814616b346e1b51bd0206442d2908747cf5072526aea30bd5105
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/daemonset-windows/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 00a226c321989d193bab95716f13fffa78c3c242c24bf238bf84780b3a4f8cc1
+        checksum/config: e2e75c24deab263399d6e1c1e9e23f4c523b36192cece416edc5c27df1906dff
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/hpa.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/deployment-use-existing-configMap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/configmap-supervisor.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/configmap-supervisor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-supervisor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d79040e53d0908cc4b092dd47560be414c578cdde10fc0e6618d7daea6af9a02
+        checksum/config: 4818ba782f89447a2834a1a63b38fa37d321573bb43ecee16b1d0f8bb099af2b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-image-versions/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -27,7 +27,7 @@ data:
         agent_description:
           include_resource_attributes: true
           non_identifying_attributes:
-            helm.chart.opentelemetry-collector.version: 0.131.4
+            helm.chart.opentelemetry-collector.version: 0.131.5
         server:
           http:
             endpoint: https://ingress./opamp/v1

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e26a7ce4196fce76fee60d3e0227d9ffca8917874655a5fa92b4d65f4473b265
+        checksum/config: 59dc289000b3ef1aba536745b6f875eae1b13adcad16295cd7198347508a939c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/configmap-supervisor.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/configmap-supervisor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-supervisor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d79040e53d0908cc4b092dd47560be414c578cdde10fc0e6618d7daea6af9a02
+        checksum/config: 4818ba782f89447a2834a1a63b38fa37d321573bb43ecee16b1d0f8bb099af2b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2677f1c01d79631efc9a32b46d94229ecf581013ca3d549a144ce3e0a68f18a7
+        checksum/config: eaec2251ef79472ecf8d5fc5f54ad9a6b32c660e513d38094595b7b8a432f0c0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f6e6025d418fc13912c64566ce0866cc8278198de77b237e6899d2bf4613e6fa
+        checksum/config: 2c3d56d5cc66a26053d2573cb7e7c30ac84726f8709955e2c486641e98e4cf3f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-disabled/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 21f48e63eb7bde38223a6b580b21c6ebe18592526c2d4dfd3a04ead6b4d9a893
+        checksum/config: 629d21ab6b5b0155f468b37e8d9182010e09f6f8b44b58b3ea98a464bf854347
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/ecs-profiles-service-name-enabled/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/ecs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ecs/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -87,7 +87,7 @@ data:
           non_identifying_attributes:
             cx.agent.type: agent
             cx.cluster.name: 'ecs'
-            helm.chart.opentelemetry-collector.version: 0.131.4
+            helm.chart.opentelemetry-collector.version: 0.131.5
         server:
           http:
             endpoint: https://ingress./opamp/v1

--- a/charts/opentelemetry-collector/examples/ecs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/ecs/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 00870379b766aec73f3bf54946cb384cf4e2904c53cdd146903b12e50ac9103a
+        checksum/config: 258be0061417c1c106871e1b1ac82c35aef9bc2d324a6824e3a91283a8b63724
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/ecs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/ecs/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: cx-otel-collector-monitor
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: cx-otel-collector-monitor
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: cx-otel-collector-monitor
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: cx-otel-collector-monitor
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cx-otel-collector-monitor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: cx-otel-collector-monitor
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cx-otel-collector-monitor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: cx-otel-collector-monitor
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f7db0396a6858cc3e6b2b587705bf5e02b4ac959c82cb493be0980fae61d6636
+        checksum/config: 292bc777947d73422cd76ad76ac343117f274eb06d252ce60a7ad6b91deab4ca
         
       labels:
         app.kubernetes.io/name: cx-otel-collector-monitor

--- a/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cx-otel-collector-monitor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: cx-otel-collector-monitor
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate-monitoring/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cx-otel-collector-monitor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: cx-otel-collector-monitor
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate/rendered/configmap-script.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate/rendered/configmap-script.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-script
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/eks-fargate/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/eks-fargate/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ec943ab3070d879aa4ac7398d7aa33b79544733dee34104cca78e4345722cd1b
+        checksum/config: 7d68b0a015839c9fd2348088c45725d5ddbc36f1ee4f5ca48a09b6ce393c443d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9bf583843dff6c61a5f7afc0031cd6b441921336ae4b75fa3f20fbbe923d783e
+        checksum/config: ac8ddef47e93eea2433b4266e70046bddf951ca344080a948fae3a14acd2f27e
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/gke-autopilot/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 089e153bfad4d3f6ceac08d2e4ee978f6931f81016dd6a5a25486270cdf1ec66
+        checksum/config: 4c79136c8a1cd6dee4758fd8cc233c336acda6e8d92b0f99b619febc32632c9c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity-events-logic/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -46,7 +46,7 @@ data:
             cx.agent.type: agent
             cx.cluster.name: test
             cx.integrationID: test
-            helm.chart.opentelemetry-collector.version: 0.131.4
+            helm.chart.opentelemetry-collector.version: 0.131.5
         server:
           http:
             endpoint: https://ingress.coralogix.com/opamp/v1

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3e28ad48771b1380452ad15665ab44e3d1e8544e50c038f02ec14ff22485b249
+        checksum/config: 1ac1ee7e159ae6f71cf911cf3763e99d7686983a941db15394dd1cfa71b15d55
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/host-entity/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c3c7705dad609a69a4a4ef67b9322e0bf299ee7c8719216cd9e04614f59b14ed
+        checksum/config: dc22ee63e91c5f0a10deed61516b5f5db8b65d25ee3cfb45a908f880ed59aac0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/kubernetesAttributes/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing-aws-cloudmap/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing-aws-cloudmap/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing-aws-cloudmap/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing-aws-cloudmap/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 750bd7a6cfd2b2a5c5dd8bbebdd77674b3d6cac08d9035cb647bfa60c116558f
+        checksum/config: 5ae1186e4e17b4e5e4c4a2f30f1e40fec25aee9c2146ed2bd14ce1fecc022f05
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/loadbalancing-aws-cloudmap/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing-aws-cloudmap/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd0e0002b6277dec8f456c82cd89b23cb70edd34c1bf6d8401bc5fdcc652a7fb
+        checksum/config: 7e23ec788bea5bf3c968760ed352a6c15f7625474f6f9d8d22ef8bab5bd822be
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/loadbalancing/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/macos-system-logs/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/macos-system-logs/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/macos-system-logs/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/macos-system-logs/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 842f6fb11c3ef250f6c45e50c172b49073e1beb92aae94526eb7e18b831cbef5
+        checksum/config: a1c3996c406fc97bc9785df0ac14038aaabb8e7efe616e7d1ef2dc1994927d95
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/macos-system-logs/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/macos-system-logs/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ccb6774c4b8110c781562205000f3600c84750482863e13cf2ef3b3cd33129b4
+        checksum/config: 63c9e3972468cb26a720e9c6f83cf24f85758660084a3acaf064c3542a9fcaf3
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/metadata/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1157b17a8caff6864f43f373a98abaaa853ded884242cc87aef8145c6cc175da
+        checksum/config: 598a8a3ca95684a84b4d2bea2cfe72a1be885c85f2ca161df762746a1c45741b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/networkmode-ipv6/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f14d3a8bb4be75aabb0611acb6c11f4ab2df42f6cb412e30f67798efb9d47985
+        checksum/config: 37e8586a8af5d58355b89f80a7a4ff2c0a8bf200b366243395f60bac7f143c40
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/on-prem-k8s/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd-security-context/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd-security-context/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd-security-context/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd-security-context/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd-security-context/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd-security-context/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding-targetallocator.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector-targetallocator
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-crd/rendered/serviceaccount-targetallocator.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-targetallocator
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector-target-allocator
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-daemonset-crd/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: otel-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-deployment-crd/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/opentelemetrycollector-ds-crd/rendered/opentelemetrycollector.yaml
+++ b/charts/opentelemetry-collector/examples/opentelemetrycollector-ds-crd/rendered/opentelemetrycollector.yaml
@@ -5,7 +5,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/configmap-supervisor.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/configmap-supervisor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-supervisor
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d79040e53d0908cc4b092dd47560be414c578cdde10fc0e6618d7daea6af9a02
+        checksum/config: 4818ba782f89447a2834a1a63b38fa37d321573bb43ecee16b1d0f8bb099af2b
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-fleet-managment/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f1bc9234ee368674a6b331eb61e8fc19e3d6d884fd95f8fbc57cc7ffa7276ef5
+        checksum/config: 21e062d19d78d5845641bb10a311c1a1d75c94026a9ce0cc17a27666300224ad
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-resource-detection/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1fdd28381820c5aac03f8c2083c1d963d55c74c920e534b471973f9df7be896c
+        checksum/config: 469a47b38243255ff31dd38d170ab6de464ebfb4e614267de5a218d7ce724853
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/profiles-with-service-labels-and-annotations/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/profiles/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca985d0bc1aa42470b8a2266f9d1f556b943d292dde43a3f443f00fb94441f5a
+        checksum/config: 7fbab63c8f46cea2be2d4982a29bbdd8d65badde58458da3760048791f53738f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/profiles/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/profiles/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: aac3ecc6b3c491d754ef06d9b1c55f10a4693da82280e1458cef100deaae655d
+        checksum/config: 283776ec9521c1c0c39c3093929b9e0b25ac9bda4825bb88cbf2865ac0e40742
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-aws-provider/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-conditions/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-conditions/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-conditions/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-conditions/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 65cf2c651314c7431d90131b2de405e1a222d7f8828ee9feac4b95740e90952c
+        checksum/config: 8721556b4c3c80704b0b40919539eb2b037f785e1703e3e20343879d6a46b8e7
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-conditions/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-conditions/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b599cd47a97e9d2a537c3b86567659f2d4a5b15416ca25e2eb876d84e89dc3ca
+        checksum/config: 7ef1e3a6f356ad44868a723877b39d39c16eec24cbfde18293df94885e004f02
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-gcp-infer/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-onprem/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-onprem/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-onprem/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-onprem/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 198eecdabc187b1d8cdaa91f430d312cdc5b10f5ae1680af057dd2604f2e85ad
+        checksum/config: 55f64c3df5f02178f3d3d380d2ec18e1e54439893bd9e60ca40cf490dfa69ecf
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-onprem/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-onprem/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-traces-provider/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-traces-provider/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-traces-provider/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-traces-provider/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 41dc95f97fab43678b6111984e61d0d50e1f6df7cd3680d3212e1ea4ee9644d1
+        checksum/config: 141d92ba93ea058ed7f55bbf3ccdde60da2aae9e367152fc22d8466898bf1d51
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/reduce-resource-attributes-traces-provider/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/reduce-resource-attributes-traces-provider/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-collector
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b33ea241212b5492139b8c073f5b5228a85b94ef760062eb84dcb0ba66723950
+        checksum/config: 2064e4e67a7822e010e744f974ee7df5fff4d3c9aff5554878a426f4e98addc0
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/resource-catalog/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
         - name: http.method
         - name: cgx.transaction
         - name: cgx.transaction.root
-        - name: http.response.status_code
-        - name: rpc.grpc.status_code
         histogram:
           explicit:
             buckets:
@@ -48,8 +46,6 @@ data:
         - name: http.method
         - name: cgx.transaction
         - name: cgx.transaction.root
-        - name: http.response.status_code
-        - name: rpc.grpc.status_code
         histogram:
           explicit:
             buckets:

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -32,6 +32,9 @@ data:
         - name: http.method
         - name: cgx.transaction
         - name: cgx.transaction.root
+        - name: http.response.status_code
+        - name: rpc.grpc.status_code
+        - name: service.version
         histogram:
           explicit:
             buckets:
@@ -46,6 +49,9 @@ data:
         - name: http.method
         - name: cgx.transaction
         - name: cgx.transaction.root
+        - name: http.response.status_code
+        - name: rpc.grpc.status_code
+        - name: service.version
         histogram:
           explicit:
             buckets:
@@ -62,6 +68,7 @@ data:
         - name: cgx.transaction.root
         - name: http.response.status_code
         - name: rpc.grpc.status_code
+        - name: service.version
         histogram:
           explicit:
             buckets:

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: baada283ce4af7947d5e1675099c5bf984adbd4393f0e27f090a02e81e3a2c37
+        checksum/config: 8ff235cf56953c0456833401867cf0ff6aae41d79ab116690207a3a9f6e56f4d
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ab0ca983a126d71d5bef8c324f36fba8e5fdb705d23afd16a03f47d9ce909576
+        checksum/config: 0a3e36265c1acdc8c849e53b7dde3f2ebbde6503715136b4ffee224bb437a70f
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/spanmetrics-multiple-preset/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone-journald/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-journald/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone-journald/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-journald/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 109f6438848a137d1e09c57778bad46755414f4bd693a820536a21320beca5c6
+        checksum/config: 7c4172109e01dcc5fb8f6415e579024e0628b8a60b5f10477d251f0c5f26e57c
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/standalone-journald/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-journald/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone-systemd/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-systemd/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone-systemd/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-systemd/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 577893bc89cd84ffd5daf2b3cac9e108a5d01229ce1574e58387dd98e0320f2a
+        checksum/config: c529bc4cf440b6a7267166210c8db4ecc33e53c098704f852f8928632dcc2c52
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/standalone-systemd/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-systemd/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone-windows/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-windows/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone-windows/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-windows/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: eb1daebf14c07c784dcdcb8277a474465662d3ddc6f62b602627568b477d9d60
+        checksum/config: 455cd44ecd40922576b082f58961a6c8a1988638e6c615b770ac4dc4ef2b5be1
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/standalone-windows/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/standalone-windows/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/standalone/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/standalone/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/standalone/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c1e23a55f78cf48b65c60130cb6394a477f8ec958bb5df065662f4c3654a8262
+        checksum/config: efa0d1b76597713cbabd1258c194ee8646ba3306a9e6f1ad5ea9757d4f546643
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/standalone/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/standalone/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/configmap-statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-statefulset
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
+++ b/charts/opentelemetry-collector/examples/statefulset-only/rendered/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 580c4e224991c90262c40f5e0c856fd9a674acf54a0eceb34bcf428cc2b4173c
+        checksum/config: d4ca8c9aa4f7f5367d1c4be5326c1730d41ac78aa675d4a48debe3e9fae418cf
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/transactions/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/transactions/rendered/configmap-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/transactions/rendered/daemonset.yaml
+++ b/charts/opentelemetry-collector/examples/transactions/rendered/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bf195f228178ffc4c2204f0ed50d2b033e520057baf1bc5dd00cfa09097f9fd3
+        checksum/config: e529e7a9c495245a086690deb04fb1fe4f7a9a36ab244077f193dfa1a4f277e5
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/transactions/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/transactions/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 62a3e84ade5e9aa40cfec637923c6c01797235eeeac20795890273897f8cc3a9
+        checksum/config: b87e8aae89bd8dca4c52d053251d7d8aa68f158174aa2982e7bddbf6cafbb092
         
       labels:
         app.kubernetes.io/name: opentelemetry-collector

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/examples/using-GOMEMLIMIT/rendered/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-opentelemetry-collector
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-collector-0.131.4
+    helm.sh/chart: opentelemetry-collector-0.131.5
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "0.151.0"

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2444,7 +2444,7 @@ processors:
 {{- end}}
 
 {{- define "opentelemetry-collector.applySpanMetricsMultiConfig" -}}
-{{- $sm := merge (dict "dbMetrics" (dict "enabled" false "compactMetrics" (dict "enabled" false)) "compactMetrics" (dict "enabled" false)) .Values.Values.presets.spanMetricsMulti }}
+{{- $sm := mergeOverwrite (dict "dbMetrics" (dict "enabled" false "compactMetrics" (dict "enabled" false)) "compactMetrics" (dict "enabled" false)) .Values.Values.presets.spanMetricsMulti }}
 {{- $hasTransformStatements := and $sm.transformStatements (gt (len $sm.transformStatements) 0) }}
 {{- $hasSpanNameReplacePattern := and $sm.spanNameReplacePattern (gt (len $sm.spanNameReplacePattern) 0) }}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.spanMetricsMultiConfig" .Values | fromYaml) .config }}
@@ -2506,7 +2506,7 @@ processors:
 {{- end }}
 
 {{- define "opentelemetry-collector.spanMetricsMultiConfig" -}}
-{{- $sm := merge (dict "dbMetrics" (dict "enabled" false "compactMetrics" (dict "enabled" false)) "compactMetrics" (dict "enabled" false)) .Values.presets.spanMetricsMulti }}
+{{- $sm := mergeOverwrite (dict "dbMetrics" (dict "enabled" false "compactMetrics" (dict "enabled" false)) "compactMetrics" (dict "enabled" false)) .Values.presets.spanMetricsMulti }}
 connectors:
   routing:
     default_pipelines: [traces/default]

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2556,9 +2556,10 @@ connectors:
     {{- else }}
     metrics_expiration: 0
     {{- end }}
-    {{- if $root.Values.presets.spanMetricsMulti.extraDimensions }}
+    {{- $extraDimensions := include "opentelemetry-collector.spanMetricsMulti.extraDimensions" $root }}
+    {{- if and $extraDimensions (gt (len $extraDimensions) 0) }}
     dimensions:
-    {{- $root.Values.presets.spanMetricsMulti.extraDimensions | toYaml | nindent 10 }}
+    {{- $extraDimensions | nindent 10 }}
     {{- end }}
   {{- end }}
 {{- include "opentelemetry-collector.spanMetricsExtras.connectors" (dict "preset" $sm "histogramBuckets" .Values.presets.spanMetricsMulti.defaultHistogramBuckets) }}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2399,20 +2399,18 @@ service:
 {{- end}}
 
 {{/*
-Routed spanmetrics/<index> connectors: only user-configured spanMetricsMulti dimensions.
-Does not fall back to presets.spanMetrics.errorTracking (preserves pre-upgrade cardinality).
+Routed spanmetrics/<index>: raw extraDimensions only; errorTracking/serviceVersion dims require
+explicit presets.spanMetricsMulti.errorTracking.enabled or serviceVersion.enabled (no spanMetrics fallback).
 */}}
 {{- define "opentelemetry-collector.spanMetricsMulti.routedExtraDimensions" -}}
 {{- if .Values.presets.spanMetricsMulti.extraDimensions }}
 {{- .Values.presets.spanMetricsMulti.extraDimensions | toYaml }}
 {{- end }}
-{{- $multiErrorTracking := .Values.presets.spanMetricsMulti.errorTracking -}}
-{{- if and $multiErrorTracking (hasKey $multiErrorTracking "enabled") $multiErrorTracking.enabled }}
+{{- if eq (dig "errorTracking" "enabled" nil .Values.presets.spanMetricsMulti) true }}
 - name: http.response.status_code
 - name: rpc.grpc.status_code
 {{- end }}
-{{- $multiServiceVersion := .Values.presets.spanMetricsMulti.serviceVersion -}}
-{{- if and $multiServiceVersion $multiServiceVersion.enabled }}
+{{- if eq (dig "serviceVersion" "enabled" nil .Values.presets.spanMetricsMulti) true }}
 - name: service.version
 {{- end }}
 {{- end}}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2398,6 +2398,25 @@ service:
 {{- end }}
 {{- end}}
 
+{{/*
+Routed spanmetrics/<index> connectors: only user-configured spanMetricsMulti dimensions.
+Does not fall back to presets.spanMetrics.errorTracking (preserves pre-upgrade cardinality).
+*/}}
+{{- define "opentelemetry-collector.spanMetricsMulti.routedExtraDimensions" -}}
+{{- if .Values.presets.spanMetricsMulti.extraDimensions }}
+{{- .Values.presets.spanMetricsMulti.extraDimensions | toYaml }}
+{{- end }}
+{{- $multiErrorTracking := .Values.presets.spanMetricsMulti.errorTracking -}}
+{{- if and $multiErrorTracking (hasKey $multiErrorTracking "enabled") $multiErrorTracking.enabled }}
+- name: http.response.status_code
+- name: rpc.grpc.status_code
+{{- end }}
+{{- $multiServiceVersion := .Values.presets.spanMetricsMulti.serviceVersion -}}
+{{- if and $multiServiceVersion $multiServiceVersion.enabled }}
+- name: service.version
+{{- end }}
+{{- end}}
+
 {{- define "opentelemetry-collector.applySpanMetricsMultiConfig" -}}
 {{- $sm := mergeOverwrite (dict "dbMetrics" (dict "enabled" false "compactMetrics" (dict "enabled" false)) "compactMetrics" (dict "enabled" false)) .Values.Values.presets.spanMetricsMulti }}
 {{- $hasTransformStatements := and $sm.transformStatements (gt (len $sm.transformStatements) 0) }}
@@ -2520,10 +2539,10 @@ connectors:
     {{- else }}
     metrics_expiration: 0
     {{- end }}
-    {{- $extraDimensions := include "opentelemetry-collector.spanMetricsMulti.extraDimensions" $root }}
-    {{- if and $extraDimensions (gt (len $extraDimensions) 0) }}
+    {{- $routedExtraDimensions := include "opentelemetry-collector.spanMetricsMulti.routedExtraDimensions" $root }}
+    {{- if and $routedExtraDimensions (gt (len $routedExtraDimensions) 0) }}
     dimensions:
-    {{- $extraDimensions | nindent 10 }}
+    {{- $routedExtraDimensions | nindent 10 }}
     {{- end }}
   {{- end }}
 {{- include "opentelemetry-collector.spanMetricsMultiExtras.connectors" (dict "preset" $sm "histogramBuckets" .Values.presets.spanMetricsMulti.defaultHistogramBuckets) }}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2105,6 +2105,256 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
 {{- end }}
 {{- end}}
 
+{{- define "opentelemetry-collector.spanMetricsExtras.connectors" -}}
+{{- $p := .preset -}}
+{{- $histogramBuckets := .histogramBuckets -}}
+{{- if $p.dbMetrics.enabled }}
+  spanmetrics/db:
+    namespace: "db"
+    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
+    dimensions:
+      - name: db.namespace
+      - name: db.operation.name
+      - name: db.collection.name
+      - name: db.system
+      {{- if $p.dbMetrics.serviceVersion.enabled }}
+      - name: service.version
+      {{- end }}
+      {{- if $p.dbMetrics.extraDimensions }}
+      {{- $p.dbMetrics.extraDimensions | toYaml | nindent 6 }}
+      {{- end }}
+{{- if $p.metricsExpiration }}
+    metrics_expiration: "{{ $p.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if $p.collectionInterval }}
+    metrics_flush_interval: "{{ $p.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+  forward/db: {}
+{{- end }}
+{{- if $p.compactMetrics.enabled }}
+  forward/compact: {}
+  spanmetrics/compact:
+    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    exclude_dimensions:
+    - span.name
+{{- if $histogramBuckets }}
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
+{{- end }}
+{{- if $p.metricsExpiration }}
+    metrics_expiration: "{{ $p.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if $p.collectionInterval }}
+    metrics_flush_interval: "{{ $p.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+    namespace: compact
+{{- end }}
+{{- if $p.dbMetrics.compactMetrics.enabled }}
+  forward/db_compact: {}
+  spanmetrics/db_compact:
+    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    dimensions:
+      - name: db.namespace
+      - name: db.system
+    exclude_dimensions:
+    - span.name
+    - span.kind
+{{- if $histogramBuckets }}
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
+{{- end }}
+{{- if $p.metricsExpiration }}
+    metrics_expiration: "{{ $p.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if $p.collectionInterval }}
+    metrics_flush_interval: "{{ $p.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+    namespace: db_compact
+{{- end }}
+{{- end -}}
+
+{{- define "opentelemetry-collector.spanMetricsExtras.processors" -}}
+{{- $p := .preset -}}
+{{- if $p.spanNameReplacePattern }}
+  transform/span_name:
+    trace_statements:
+      - context: span
+        statements:
+        {{- range $index, $pattern := $p.spanNameReplacePattern }}
+        - replace_pattern(span.name, "{{ $pattern.regex }}", "{{ $pattern.replacement }}")
+        {{- end}}
+{{- end }}
+{{- if $p.dbMetrics.enabled }}
+  filter/db_spanmetrics:
+    traces:
+      span:
+        - 'attributes["db.system"] == nil'
+{{- end }}
+{{- if $p.dbMetrics.compactMetrics.enabled }}
+  filter/db_compact_spanmetrics:
+    traces:
+      span:
+        - 'kind != SPAN_KIND_CLIENT or attributes["db.namespace"] == nil or attributes["db.system"] == nil'
+{{- end }}
+{{- if $p.dbMetrics.transformStatements }}
+  transform/db:
+    error_mode: silent
+    trace_statements:
+      - context: span
+        statements:
+        {{- range $index, $pattern := $p.dbMetrics.transformStatements }}
+        - {{ $pattern }}
+        {{- end}}
+{{- end }}
+{{- if $p.compactMetrics.enabled }}
+  transform/compact:
+    trace_statements:
+      - context: resource
+        statements:
+          - keep_keys(attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
+{{- end }}
+{{- if $p.dbMetrics.compactMetrics.enabled }}
+  transform/db_compact:
+    trace_statements:
+      - context: resource
+        statements:
+          - keep_keys(attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
+      - context: span
+        statements:
+          - keep_keys(attributes, ["db.namespace", "db.system"])
+{{- end }}
+{{- if and ($p.compactMetrics.enabled) ($p.compactMetrics.dropHistogram) }}
+  transform/compact_histogram:
+    metric_statements:
+      - context: metric
+        statements:
+          - extract_sum_metric(false, ".sum") where name == "compact.duration"
+          - extract_count_metric(false, ".count") where name == "compact.duration"
+          - set(unit, "") where name == "compact.duration.sum"
+          - set(unit, "") where name == "compact.duration.count"
+          - set(name, "compact.duration.ms.sum") where name == "compact.duration.sum"
+          - set(name, "compact.duration.ms.count") where name == "compact.duration.count"
+  filter/drop_histogram:
+    metrics:
+      metric:
+        - 'name == "compact.duration"'
+{{- end }}
+{{- if and ($p.dbMetrics.compactMetrics.enabled) ($p.dbMetrics.compactMetrics.dropHistogram) }}
+  transform/db_compact_histogram:
+    metric_statements:
+      - context: metric
+        statements:
+          - extract_sum_metric(false, ".sum") where name == "db_compact.duration"
+          - extract_count_metric(false, ".count") where name == "db_compact.duration"
+          - set(unit, "") where name == "db_compact.duration.sum"
+          - set(unit, "") where name == "db_compact.duration.count"
+          - set(name, "db_compact.duration.ms.sum") where name == "db_compact.duration.sum"
+          - set(name, "db_compact.duration.ms.count") where name == "db_compact.duration.count"
+  filter/drop_db_compact_histogram:
+    metrics:
+      metric:
+        - 'name == "db_compact.duration"'
+{{- end }}
+{{- end -}}
+
+{{- define "opentelemetry-collector.spanMetricsExtras.service" -}}
+{{- $p := .preset -}}
+{{- $transformProcessor := .transformProcessor -}}
+{{- $compactMetricsExporters := .compactMetricsExporters | default (list "coralogix") -}}
+{{- if or ($p.dbMetrics.enabled) ($p.compactMetrics.enabled) ($p.dbMetrics.compactMetrics.enabled) }}
+service:
+  pipelines:
+{{- if $p.dbMetrics.enabled }}
+    traces/db:
+      exporters:
+      - spanmetrics/db
+      processors:
+      - filter/db_spanmetrics
+      {{- if $p.dbMetrics.transformStatements }}
+      - transform/db
+      {{- end }}
+      - batch
+      receivers:
+      - forward/db
+{{- end }}
+{{- if $p.compactMetrics.enabled }}
+    traces/compact:
+      exporters:
+      - spanmetrics/compact
+      processors:
+      - transform/compact
+      - batch
+      receivers:
+      - forward/compact
+    metrics/compact:
+      receivers:
+      - spanmetrics/compact
+      processors:
+      - memory_limiter
+      - {{ $transformProcessor }}
+      {{- if $p.compactMetrics.dropHistogram }}
+      - transform/compact_histogram
+      - filter/drop_histogram
+      {{- end }}
+      - batch
+      exporters:
+      {{- $compactMetricsExporters | toYaml | nindent 6 }}
+{{- end }}
+{{- if $p.dbMetrics.compactMetrics.enabled }}
+    traces/db_compact:
+      exporters:
+      - spanmetrics/db_compact
+      processors:
+      - filter/db_compact_spanmetrics
+      - transform/db_compact
+      - batch
+      receivers:
+      - forward/db_compact
+    metrics/db_compact:
+      receivers:
+      - spanmetrics/db_compact
+      processors:
+      - memory_limiter
+      - {{ $transformProcessor }}
+      {{- if $p.dbMetrics.compactMetrics.dropHistogram }}
+      - transform/db_compact_histogram
+      - filter/drop_db_compact_histogram
+      {{- end }}
+      - batch
+      exporters:
+      {{- $compactMetricsExporters | toYaml | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "opentelemetry-collector.spanMetricsExtrasEnabled" -}}
+{{- $p := . -}}
+{{- or ($p.spanNameReplacePattern) ($p.dbMetrics.enabled) ($p.transformStatements) ($p.compactMetrics.enabled) ($p.dbMetrics.compactMetrics.enabled) -}}
+{{- end -}}
+
 {{- define "opentelemetry-collector.spanMetricsConfig" -}}
 connectors:
   spanmetrics:
@@ -2136,116 +2386,11 @@ connectors:
 {{- else }}
     metrics_expiration: 0
 {{- end }}
-{{- if .Values.presets.spanMetrics.dbMetrics.enabled }}
-  spanmetrics/db:
-    namespace: "db"
-    aggregation_cardinality_limit: {{ .Values.presets.spanMetrics.aggregationCardinalityLimit }}
-    add_resource_attributes: true
-    histogram:
-      unit: ms
-      explicit:
-        buckets: {{ .Values.presets.spanMetrics.histogramBuckets | toYaml | nindent 12 }}
-    dimensions:
-      - name: db.namespace
-      - name: db.operation.name
-      - name: db.collection.name
-      - name: db.system
-      {{- if .Values.presets.spanMetrics.dbMetrics.serviceVersion.enabled }}
-      - name: service.version
-      {{- end }}
-      {{- if .Values.presets.spanMetrics.dbMetrics.extraDimensions }}
-      {{- .Values.presets.spanMetrics.dbMetrics.extraDimensions | toYaml | nindent 6 }}
-      {{- end }}
-{{- if .Values.presets.spanMetrics.metricsExpiration }}
-    metrics_expiration: "{{ .Values.presets.spanMetrics.metricsExpiration }}"
-{{- else }}
-    metrics_expiration: 0
-{{- end }}
-{{- if .Values.presets.spanMetrics.collectionInterval }}
-    metrics_flush_interval: "{{ .Values.presets.spanMetrics.collectionInterval }}"
-{{- else }}
-    metrics_flush_interval: 15s
-{{- end }}
-  forward/db: {}
-{{- end }}
-{{- if .Values.presets.spanMetrics.compactMetrics.enabled }}
-  forward/compact: {}
-  spanmetrics/compact:
-    aggregation_cardinality_limit: {{ .Values.presets.spanMetrics.aggregationCardinalityLimit }}
-    add_resource_attributes: true
-    exclude_dimensions:
-    - span.name
-{{- if .Values.presets.spanMetrics.histogramBuckets }}
-    histogram:
-      unit: ms
-      explicit:
-        buckets: {{ .Values.presets.spanMetrics.histogramBuckets | toYaml | nindent 12 }}
-{{- end }}
-{{- if .Values.presets.spanMetrics.metricsExpiration }}
-    metrics_expiration: "{{ .Values.presets.spanMetrics.metricsExpiration }}"
-{{- else }}
-    metrics_expiration: 0
-{{- end }}
-{{- if .Values.presets.spanMetrics.collectionInterval }}
-    metrics_flush_interval: "{{ .Values.presets.spanMetrics.collectionInterval }}"
-{{- else }}
-    metrics_flush_interval: 15s
-{{- end }}
-    namespace: compact
-{{- end }}
-{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
-  forward/db_compact: {}
-  spanmetrics/db_compact:
-    aggregation_cardinality_limit: {{ .Values.presets.spanMetrics.aggregationCardinalityLimit }}
-    add_resource_attributes: true
-    dimensions:
-      - name: db.namespace
-      - name: db.system
-    exclude_dimensions:
-    - span.name
-    - span.kind
-{{- if .Values.presets.spanMetrics.histogramBuckets }}
-    histogram:
-      unit: ms
-      explicit:
-        buckets: {{ .Values.presets.spanMetrics.histogramBuckets | toYaml | nindent 12 }}
-{{- end }}
-{{- if .Values.presets.spanMetrics.metricsExpiration }}
-    metrics_expiration: "{{ .Values.presets.spanMetrics.metricsExpiration }}"
-{{- else }}
-    metrics_expiration: 0
-{{- end }}
-{{- if .Values.presets.spanMetrics.collectionInterval }}
-    metrics_flush_interval: "{{ .Values.presets.spanMetrics.collectionInterval }}"
-{{- else }}
-    metrics_flush_interval: 15s
-{{- end }}
-    namespace: db_compact
-{{- end }}
-{{- if or (.Values.presets.spanMetrics.enabled) (.Values.presets.spanMetrics.spanNameReplacePattern) (.Values.presets.spanMetrics.dbMetrics.enabled) (.Values.presets.spanMetrics.transformStatements) (.Values.presets.spanMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled) (.Values.presets.spanMetricsMulti.enabled) }}
+{{- include "opentelemetry-collector.spanMetricsExtras.connectors" (dict "preset" .Values.presets.spanMetrics "histogramBuckets" .Values.presets.spanMetrics.histogramBuckets) }}
+{{- if or (.Values.presets.spanMetrics.enabled) (include "opentelemetry-collector.spanMetricsExtrasEnabled" .Values.presets.spanMetrics) }}
 processors:
 {{- end}}
-{{- if .Values.presets.spanMetrics.spanNameReplacePattern }}
-  transform/span_name:
-    trace_statements:
-      - context: span
-        statements:
-        {{- range $index, $pattern := .Values.presets.spanMetrics.spanNameReplacePattern }}
-        - replace_pattern(span.name, "{{ $pattern.regex }}", "{{ $pattern.replacement }}")
-        {{- end}}
-{{- end }}
-{{- if .Values.presets.spanMetrics.dbMetrics.enabled }}
-  filter/db_spanmetrics:
-    traces:
-      span:
-        - 'attributes["db.system"] == nil'
-{{- end }}
-{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
-  filter/db_compact_spanmetrics:
-    traces:
-      span:
-        - 'kind != SPAN_KIND_CLIENT or attributes["db.namespace"] == nil or attributes["db.system"] == nil'
-{{- end }}
+{{- include "opentelemetry-collector.spanMetricsExtras.processors" (dict "preset" .Values.presets.spanMetrics) }}
 {{- if .Values.presets.spanMetrics.enabled }}
   transform/spanmetrics:
     error_mode: silent
@@ -2262,147 +2407,29 @@ processors:
         {{- end}}
     {{- end }}
 {{- end }}
-{{- if .Values.presets.spanMetrics.dbMetrics.transformStatements }}
-  transform/db:
-    error_mode: silent
-    trace_statements:
-      - context: span
-        statements:
-        {{- range $index, $pattern := .Values.presets.spanMetrics.dbMetrics.transformStatements }}
-        - {{ $pattern }}
-        {{- end}}
-{{- end }}
-{{- if .Values.presets.spanMetrics.compactMetrics.enabled }}
-  transform/compact:
-    trace_statements:
-      - context: resource
-        statements:
-          - keep_keys(attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
-{{- end }}
-{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
-  transform/db_compact:
-    trace_statements:
-      - context: resource
-        statements:
-          - keep_keys(attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
-      - context: span
-        statements:
-          - keep_keys(attributes, ["db.namespace", "db.system"])
-{{- end }}
-{{- if and (.Values.presets.spanMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.compactMetrics.dropHistogram) }}
-  transform/compact_histogram:
-    metric_statements:
-      - context: metric
-        statements:
-          - extract_sum_metric(false, ".sum") where name == "compact.duration"
-          - extract_count_metric(false, ".count") where name == "compact.duration"
-          - set(unit, "") where name == "compact.duration.sum"
-          - set(unit, "") where name == "compact.duration.count"
-          - set(name, "compact.duration.ms.sum") where name == "compact.duration.sum"
-          - set(name, "compact.duration.ms.count") where name == "compact.duration.count"
-  filter/drop_histogram:
-    metrics:
-      metric:
-        - 'name == "compact.duration"'
-{{- end }}
-{{- if and (.Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.dbMetrics.compactMetrics.dropHistogram) }}
-  transform/db_compact_histogram:
-    metric_statements:
-      - context: metric
-        statements:
-          - extract_sum_metric(false, ".sum") where name == "db_compact.duration"
-          - extract_count_metric(false, ".count") where name == "db_compact.duration"
-          - set(unit, "") where name == "db_compact.duration.sum"
-          - set(unit, "") where name == "db_compact.duration.count"
-          - set(name, "db_compact.duration.ms.sum") where name == "db_compact.duration.sum"
-          - set(name, "db_compact.duration.ms.count") where name == "db_compact.duration.count"
-  filter/drop_db_compact_histogram:
-    metrics:
-      metric:
-        - 'name == "db_compact.duration"'
-{{- end }}
-{{- if or (.Values.presets.spanMetrics.dbMetrics.enabled) (.Values.presets.spanMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled) }}
-service:
-  pipelines:
-{{- if .Values.presets.spanMetrics.dbMetrics.enabled }}
-    traces/db:
-      exporters:
-      - spanmetrics/db
-      processors:
-      - filter/db_spanmetrics
-      {{- if .Values.presets.spanMetrics.dbMetrics.transformStatements }}
-      - transform/db
-      {{- end }}
-      - batch
-      receivers:
-      - forward/db
-{{- end }}
-{{- if .Values.presets.spanMetrics.compactMetrics.enabled }}
-    traces/compact:
-      exporters:
-      - spanmetrics/compact
-      processors:
-      - transform/compact
-      - batch
-      receivers:
-      - forward/compact
-    metrics/compact:
-      receivers:
-      - spanmetrics/compact
-      processors:
-      - memory_limiter
-      - transform/spanmetrics
-      {{- if .Values.presets.spanMetrics.compactMetrics.dropHistogram }}
-      - transform/compact_histogram
-      - filter/drop_histogram
-      {{- end }}
-      - batch
-      exporters:
-      - coralogix
-{{- end }}
-{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
-    traces/db_compact:
-      exporters:
-      - spanmetrics/db_compact
-      processors:
-      - filter/db_compact_spanmetrics
-      - transform/db_compact
-      - batch
-      receivers:
-      - forward/db_compact
-    metrics/db_compact:
-      receivers:
-      - spanmetrics/db_compact
-      processors:
-      - memory_limiter
-      - transform/spanmetrics
-      {{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.dropHistogram }}
-      - transform/db_compact_histogram
-      - filter/drop_db_compact_histogram
-      {{- end }}
-      - batch
-      exporters:
-      - coralogix
-{{- end }}
-{{- end }}
-{{- end }}
+{{- include "opentelemetry-collector.spanMetricsExtras.service" (dict "preset" .Values.presets.spanMetrics "transformProcessor" "transform/spanmetrics") }}
+{{- end -}}
 
-{{- define "opentelemetry-collector.spanMetricsMulti.extraDimensions" }}
+{{- define "opentelemetry-collector.spanMetricsMulti.extraDimensions" -}}
 {{- if .Values.presets.spanMetricsMulti.extraDimensions }}
 {{- .Values.presets.spanMetricsMulti.extraDimensions | toYaml }}
 {{- end }}
-{{- if .Values.presets.spanMetrics.errorTracking.enabled }}
+{{- if .Values.presets.spanMetricsMulti.errorTracking.enabled }}
 - name: http.response.status_code
 - name: rpc.grpc.status_code
+{{- end }}
+{{- if .Values.presets.spanMetricsMulti.serviceVersion.enabled }}
+- name: service.version
 {{- end }}
 {{- end}}
 
 {{- define "opentelemetry-collector.applySpanMetricsMultiConfig" -}}
+{{- $sm := .Values.Values.presets.spanMetricsMulti }}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.spanMetricsMultiConfig" .Values | fromYaml) .config }}
 {{- $tracesPipeline := deepCopy $config.service.pipelines.traces }}
 {{- $_ := set $tracesPipeline "processors" (list "batch") }}
 {{- $_ := set $tracesPipeline "receivers" (list "routing") }}
-{{- range $index, $cfg := .Values.Values.presets.spanMetricsMulti.configs }}
+{{- range $index, $cfg := $sm.configs }}
 {{- $pipeline := deepCopy $tracesPipeline}}
 {{- $pipelineKey := (printf "traces/%d" $index) }}
 {{- $_ := set $pipeline "exporters" (append $pipeline.exporters (printf "spanmetrics/%d" $index) ) }}
@@ -2412,15 +2439,45 @@ service:
 {{- $_ := set $pipeline "exporters" (append $pipeline.exporters "spanmetrics/default" ) }}
 {{- $_ := merge $config.service.pipelines (dict "traces/default" $pipeline )  }}
 {{- if $config.service.pipelines.traces }}
-{{- $_ := set $config.service.pipelines.traces "exporters" (list "routing") }}
+{{- $tracesExporters := list "routing" }}
+{{- if $sm.dbMetrics.enabled }}
+{{- $tracesExporters = append $tracesExporters "forward/db" | uniq }}
+{{- end }}
+{{- if $sm.compactMetrics.enabled }}
+{{- $tracesExporters = append $tracesExporters "forward/compact" | uniq }}
+{{- end }}
+{{- if $sm.dbMetrics.compactMetrics.enabled }}
+{{- $tracesExporters = append $tracesExporters "forward/db_compact" | uniq }}
+{{- end }}
+{{- $_ := set $config.service.pipelines.traces "exporters" $tracesExporters }}
+{{- if $sm.transformStatements }}
+{{- if not (has "transform/spanmetricsmulti" $config.service.pipelines.traces.processors) }}
+{{- $_ := set $config.service.pipelines.traces "processors" (append $config.service.pipelines.traces.processors "transform/spanmetricsmulti" | uniq) }}
+{{- end }}
+{{- end }}
+{{- if $sm.spanNameReplacePattern }}
+{{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors "transform/span_name" | uniq) }}
+{{- end }}
 {{- end }}
 {{- if $config.service.pipelines.metrics }}
-{{- range $index, $cfg := .Values.Values.presets.spanMetricsMulti.configs }}
+{{- $metricsExporters := $config.service.pipelines.metrics.exporters | default (list "coralogix") }}
+{{- range $index, $cfg := $sm.configs }}
 {{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers (printf "spanmetrics/%d" $index))  }}
 {{- end }}
 {{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "spanmetrics/default")  }}
+{{- if $sm.dbMetrics.enabled }}
+{{- if not (has "spanmetrics/db" $config.service.pipelines.metrics.receivers) }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "spanmetrics/db" | uniq) }}
+{{- end }}
+{{- end }}
 {{- if and ($config.service.pipelines.metrics) (not (has "transform/spanmetricsmulti" $config.service.pipelines.metrics.processors)) }}
 {{- $_ := set $config.service.pipelines.metrics "processors" (append $config.service.pipelines.metrics.processors "transform/spanmetricsmulti" | uniq)  }}
+{{- end }}
+{{- if index $config.service.pipelines "metrics/compact" }}
+{{- $_ := set (index $config.service.pipelines "metrics/compact") "exporters" $metricsExporters }}
+{{- end }}
+{{- if index $config.service.pipelines "metrics/db_compact" }}
+{{- $_ := set (index $config.service.pipelines "metrics/db_compact") "exporters" $metricsExporters }}
 {{- end }}
 {{- end }}
 {{- $config | toYaml }}
@@ -2437,8 +2494,8 @@ connectors:
         pipelines: [traces/{{- $index }}]
       {{- end }}
   spanmetrics/default:
-{{- if .Values.presets.spanMetrics.namespace }}
-    namespace: "{{ .Values.presets.spanMetrics.namespace }}"
+{{- if .Values.presets.spanMetricsMulti.namespace }}
+    namespace: "{{ .Values.presets.spanMetricsMulti.namespace }}"
 {{- else }}
     namespace: ""
 {{- end }}
@@ -2483,20 +2540,32 @@ connectors:
     {{- else }}
     metrics_expiration: 0
     {{- end }}
-    {{- if $root.Values.presets.spanMetricsMulti.extraDimensions }}
+    {{- $extraDimensions := include "opentelemetry-collector.spanMetricsMulti.extraDimensions" $root }}
+    {{- if and $extraDimensions (gt (len $extraDimensions) 0) }}
     dimensions:
-    {{- $root.Values.presets.spanMetricsMulti.extraDimensions | toYaml | nindent 10 }}
+    {{- $extraDimensions | nindent 10 }}
     {{- end }}
   {{- end }}
-
+{{- include "opentelemetry-collector.spanMetricsExtras.connectors" (dict "preset" .Values.presets.spanMetricsMulti "histogramBuckets" .Values.presets.spanMetricsMulti.defaultHistogramBuckets) }}
+{{- if or (include "opentelemetry-collector.spanMetricsExtrasEnabled" .Values.presets.spanMetricsMulti) true }}
 processors:
+{{- end }}
   transform/spanmetricsmulti:
     error_mode: silent
     metric_statements:
       - context: datapoint
         statements:
         {{- include "opentelemetry-collector.spanMetricsStatusCodeStatements" . | nindent 8 }}
-
+    {{- if .Values.presets.spanMetricsMulti.transformStatements }}
+    trace_statements:
+      - context: span
+        statements:
+        {{- range $index, $pattern := .Values.presets.spanMetricsMulti.transformStatements }}
+        - {{ $pattern }}
+        {{- end }}
+    {{- end }}
+{{- include "opentelemetry-collector.spanMetricsExtras.processors" (dict "preset" .Values.presets.spanMetricsMulti) }}
+{{- include "opentelemetry-collector.spanMetricsExtras.service" (dict "preset" .Values.presets.spanMetricsMulti "transformProcessor" "transform/spanmetricsmulti") }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubernetesResourcesConfig" -}}

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2096,269 +2096,6 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
 {{- end }}
 {{- end}}
 
-{{- define "opentelemetry-collector.spanMetricsExtras.connectors" -}}
-{{- $p := .preset -}}
-{{- $histogramBuckets := .histogramBuckets -}}
-{{- $dbMetrics := $p.dbMetrics | default dict -}}
-{{- $compactMetrics := $p.compactMetrics | default dict -}}
-{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
-{{- if $dbMetrics.enabled }}
-  spanmetrics/db:
-    namespace: "db"
-    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
-    add_resource_attributes: true
-    histogram:
-      unit: ms
-      explicit:
-        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
-    dimensions:
-      - name: db.namespace
-      - name: db.operation.name
-      - name: db.collection.name
-      - name: db.system
-      {{- $dbServiceVersion := $dbMetrics.serviceVersion | default dict -}}
-      {{- if and $dbServiceVersion $dbServiceVersion.enabled }}
-      - name: service.version
-      {{- end }}
-      {{- if $dbMetrics.extraDimensions }}
-      {{- $dbMetrics.extraDimensions | toYaml | nindent 6 }}
-      {{- end }}
-{{- if $p.metricsExpiration }}
-    metrics_expiration: "{{ $p.metricsExpiration }}"
-{{- else }}
-    metrics_expiration: 0
-{{- end }}
-{{- if $p.collectionInterval }}
-    metrics_flush_interval: "{{ $p.collectionInterval }}"
-{{- else }}
-    metrics_flush_interval: 15s
-{{- end }}
-  forward/db: {}
-{{- end }}
-{{- if $compactMetrics.enabled }}
-  forward/compact: {}
-  spanmetrics/compact:
-    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
-    add_resource_attributes: true
-    exclude_dimensions:
-    - span.name
-{{- if $histogramBuckets }}
-    histogram:
-      unit: ms
-      explicit:
-        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
-{{- end }}
-{{- if $p.metricsExpiration }}
-    metrics_expiration: "{{ $p.metricsExpiration }}"
-{{- else }}
-    metrics_expiration: 0
-{{- end }}
-{{- if $p.collectionInterval }}
-    metrics_flush_interval: "{{ $p.collectionInterval }}"
-{{- else }}
-    metrics_flush_interval: 15s
-{{- end }}
-    namespace: compact
-{{- end }}
-{{- if $dbCompactMetrics.enabled }}
-  forward/db_compact: {}
-  spanmetrics/db_compact:
-    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
-    add_resource_attributes: true
-    dimensions:
-      - name: db.namespace
-      - name: db.system
-    exclude_dimensions:
-    - span.name
-    - span.kind
-{{- if $histogramBuckets }}
-    histogram:
-      unit: ms
-      explicit:
-        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
-{{- end }}
-{{- if $p.metricsExpiration }}
-    metrics_expiration: "{{ $p.metricsExpiration }}"
-{{- else }}
-    metrics_expiration: 0
-{{- end }}
-{{- if $p.collectionInterval }}
-    metrics_flush_interval: "{{ $p.collectionInterval }}"
-{{- else }}
-    metrics_flush_interval: 15s
-{{- end }}
-    namespace: db_compact
-{{- end }}
-{{- end -}}
-
-{{- define "opentelemetry-collector.spanMetricsExtras.processors" -}}
-{{- $p := .preset -}}
-{{- $dbMetrics := $p.dbMetrics | default dict -}}
-{{- $compactMetrics := $p.compactMetrics | default dict -}}
-{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
-{{- if and $p.spanNameReplacePattern (gt (len $p.spanNameReplacePattern) 0) }}
-  transform/span_name:
-    trace_statements:
-      - context: span
-        statements:
-        {{- range $index, $pattern := $p.spanNameReplacePattern }}
-        - replace_pattern(span.name, "{{ $pattern.regex }}", "{{ $pattern.replacement }}")
-        {{- end}}
-{{- end }}
-{{- if $dbMetrics.enabled }}
-  filter/db_spanmetrics:
-    traces:
-      span:
-        - 'span.attributes["db.system"] == nil'
-{{- end }}
-{{- if $dbCompactMetrics.enabled }}
-  filter/db_compact_spanmetrics:
-    traces:
-      span:
-        - 'span.kind != SPAN_KIND_CLIENT or span.attributes["db.namespace"] == nil or span.attributes["db.system"] == nil'
-{{- end }}
-{{- if and $dbMetrics.transformStatements (gt (len $dbMetrics.transformStatements) 0) }}
-  transform/db:
-    error_mode: silent
-    trace_statements:
-      - context: span
-        statements:
-        {{- range $index, $pattern := $dbMetrics.transformStatements }}
-        - {{ $pattern }}
-        {{- end}}
-{{- end }}
-{{- if $compactMetrics.enabled }}
-  transform/compact:
-    trace_statements:
-      - context: resource
-        statements:
-          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
-{{- end }}
-{{- if $dbCompactMetrics.enabled }}
-  transform/db_compact:
-    trace_statements:
-      - context: resource
-        statements:
-          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
-      - context: span
-        statements:
-          - keep_keys(span.attributes, ["db.namespace", "db.system"])
-{{- end }}
-{{- if and ($compactMetrics.enabled) ($compactMetrics.dropHistogram) }}
-  transform/compact_histogram:
-    metric_statements:
-      - context: metric
-        statements:
-          - extract_sum_metric(false, ".sum") where metric.name == "compact.duration"
-          - extract_count_metric(false, ".count") where metric.name == "compact.duration"
-          - set(metric.unit, "") where metric.name == "compact.duration.sum"
-          - set(metric.unit, "") where metric.name == "compact.duration.count"
-          - set(metric.name, "compact.duration.ms.sum") where metric.name == "compact.duration.sum"
-          - set(metric.name, "compact.duration.ms.count") where metric.name == "compact.duration.count"
-  filter/drop_histogram:
-    metrics:
-      metric:
-        - 'metric.name == "compact.duration"'
-{{- end }}
-{{- if and ($dbCompactMetrics.enabled) ($dbCompactMetrics.dropHistogram) }}
-  transform/db_compact_histogram:
-    metric_statements:
-      - context: metric
-        statements:
-          - extract_sum_metric(false, ".sum") where metric.name == "db_compact.duration"
-          - extract_count_metric(false, ".count") where metric.name == "db_compact.duration"
-          - set(metric.unit, "") where metric.name == "db_compact.duration.sum"
-          - set(metric.unit, "") where metric.name == "db_compact.duration.count"
-          - set(metric.name, "db_compact.duration.ms.sum") where metric.name == "db_compact.duration.sum"
-          - set(metric.name, "db_compact.duration.ms.count") where metric.name == "db_compact.duration.count"
-  filter/drop_db_compact_histogram:
-    metrics:
-      metric:
-        - 'metric.name == "db_compact.duration"'
-{{- end }}
-{{- end -}}
-
-{{- define "opentelemetry-collector.spanMetricsExtras.service" -}}
-{{- $p := .preset -}}
-{{- $dbMetrics := $p.dbMetrics | default dict -}}
-{{- $compactMetrics := $p.compactMetrics | default dict -}}
-{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
-{{- $transformProcessor := .transformProcessor -}}
-{{- $compactMetricsExporters := .compactMetricsExporters | default (list "coralogix") -}}
-{{- if or ($dbMetrics.enabled) ($compactMetrics.enabled) ($dbCompactMetrics.enabled) }}
-service:
-  pipelines:
-{{- if $dbMetrics.enabled }}
-    traces/db:
-      exporters:
-      - spanmetrics/db
-      processors:
-      - filter/db_spanmetrics
-      {{- if and $dbMetrics.transformStatements (gt (len $dbMetrics.transformStatements) 0) }}
-      - transform/db
-      {{- end }}
-      - batch
-      receivers:
-      - forward/db
-{{- end }}
-{{- if $compactMetrics.enabled }}
-    traces/compact:
-      exporters:
-      - spanmetrics/compact
-      processors:
-      - transform/compact
-      - batch
-      receivers:
-      - forward/compact
-    metrics/compact:
-      receivers:
-      - spanmetrics/compact
-      processors:
-      - memory_limiter
-      - {{ $transformProcessor }}
-      {{- if $compactMetrics.dropHistogram }}
-      - transform/compact_histogram
-      - filter/drop_histogram
-      {{- end }}
-      - batch
-      exporters:
-      {{- $compactMetricsExporters | toYaml | nindent 6 }}
-{{- end }}
-{{- if $dbCompactMetrics.enabled }}
-    traces/db_compact:
-      exporters:
-      - spanmetrics/db_compact
-      processors:
-      - filter/db_compact_spanmetrics
-      - transform/db_compact
-      - batch
-      receivers:
-      - forward/db_compact
-    metrics/db_compact:
-      receivers:
-      - spanmetrics/db_compact
-      processors:
-      - memory_limiter
-      - {{ $transformProcessor }}
-      {{- if $dbCompactMetrics.dropHistogram }}
-      - transform/db_compact_histogram
-      - filter/drop_db_compact_histogram
-      {{- end }}
-      - batch
-      exporters:
-      {{- $compactMetricsExporters | toYaml | nindent 6 }}
-{{- end }}
-{{- end }}
-{{- end -}}
-
-{{- define "opentelemetry-collector.spanMetricsExtrasEnabled" -}}
-{{- $p := . -}}
-{{- $dbMetrics := $p.dbMetrics | default dict -}}
-{{- $compactMetrics := $p.compactMetrics | default dict -}}
-{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
-{{- or (and $p.spanNameReplacePattern (gt (len $p.spanNameReplacePattern) 0)) ($dbMetrics.enabled) (and $p.transformStatements (gt (len $p.transformStatements) 0)) ($compactMetrics.enabled) ($dbCompactMetrics.enabled) -}}
-{{- end -}}
-
 {{- define "opentelemetry-collector.spanMetricsConfig" -}}
 connectors:
   spanmetrics:
@@ -2390,11 +2127,116 @@ connectors:
 {{- else }}
     metrics_expiration: 0
 {{- end }}
-{{- include "opentelemetry-collector.spanMetricsExtras.connectors" (dict "preset" .Values.presets.spanMetrics "histogramBuckets" .Values.presets.spanMetrics.histogramBuckets) }}
-{{- if or (.Values.presets.spanMetrics.enabled) (include "opentelemetry-collector.spanMetricsExtrasEnabled" .Values.presets.spanMetrics) }}
+{{- if .Values.presets.spanMetrics.dbMetrics.enabled }}
+  spanmetrics/db:
+    namespace: "db"
+    aggregation_cardinality_limit: {{ .Values.presets.spanMetrics.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ .Values.presets.spanMetrics.histogramBuckets | toYaml | nindent 12 }}
+    dimensions:
+      - name: db.namespace
+      - name: db.operation.name
+      - name: db.collection.name
+      - name: db.system
+      {{- if .Values.presets.spanMetrics.dbMetrics.serviceVersion.enabled }}
+      - name: service.version
+      {{- end }}
+      {{- if .Values.presets.spanMetrics.dbMetrics.extraDimensions }}
+      {{- .Values.presets.spanMetrics.dbMetrics.extraDimensions | toYaml | nindent 6 }}
+      {{- end }}
+{{- if .Values.presets.spanMetrics.metricsExpiration }}
+    metrics_expiration: "{{ .Values.presets.spanMetrics.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if .Values.presets.spanMetrics.collectionInterval }}
+    metrics_flush_interval: "{{ .Values.presets.spanMetrics.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+  forward/db: {}
+{{- end }}
+{{- if .Values.presets.spanMetrics.compactMetrics.enabled }}
+  forward/compact: {}
+  spanmetrics/compact:
+    aggregation_cardinality_limit: {{ .Values.presets.spanMetrics.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    exclude_dimensions:
+    - span.name
+{{- if .Values.presets.spanMetrics.histogramBuckets }}
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ .Values.presets.spanMetrics.histogramBuckets | toYaml | nindent 12 }}
+{{- end }}
+{{- if .Values.presets.spanMetrics.metricsExpiration }}
+    metrics_expiration: "{{ .Values.presets.spanMetrics.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if .Values.presets.spanMetrics.collectionInterval }}
+    metrics_flush_interval: "{{ .Values.presets.spanMetrics.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+    namespace: compact
+{{- end }}
+{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
+  forward/db_compact: {}
+  spanmetrics/db_compact:
+    aggregation_cardinality_limit: {{ .Values.presets.spanMetrics.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    dimensions:
+      - name: db.namespace
+      - name: db.system
+    exclude_dimensions:
+    - span.name
+    - span.kind
+{{- if .Values.presets.spanMetrics.histogramBuckets }}
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ .Values.presets.spanMetrics.histogramBuckets | toYaml | nindent 12 }}
+{{- end }}
+{{- if .Values.presets.spanMetrics.metricsExpiration }}
+    metrics_expiration: "{{ .Values.presets.spanMetrics.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if .Values.presets.spanMetrics.collectionInterval }}
+    metrics_flush_interval: "{{ .Values.presets.spanMetrics.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+    namespace: db_compact
+{{- end }}
+{{- if or (.Values.presets.spanMetrics.enabled) (.Values.presets.spanMetrics.spanNameReplacePattern) (.Values.presets.spanMetrics.dbMetrics.enabled) (.Values.presets.spanMetrics.transformStatements) (.Values.presets.spanMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled) (.Values.presets.spanMetricsMulti.enabled) }}
 processors:
 {{- end}}
-{{- include "opentelemetry-collector.spanMetricsExtras.processors" (dict "preset" .Values.presets.spanMetrics) }}
+{{- if .Values.presets.spanMetrics.spanNameReplacePattern }}
+  transform/span_name:
+    trace_statements:
+      - context: span
+        statements:
+        {{- range $index, $pattern := .Values.presets.spanMetrics.spanNameReplacePattern }}
+        - replace_pattern(span.name, "{{ $pattern.regex }}", "{{ $pattern.replacement }}")
+        {{- end}}
+{{- end }}
+{{- if .Values.presets.spanMetrics.dbMetrics.enabled }}
+  filter/db_spanmetrics:
+    traces:
+      span:
+        - 'span.attributes["db.system"] == nil'
+{{- end }}
+{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
+  filter/db_compact_spanmetrics:
+    traces:
+      span:
+        - 'span.kind != SPAN_KIND_CLIENT or span.attributes["db.namespace"] == nil or span.attributes["db.system"] == nil'
+{{- end }}
 {{- if .Values.presets.spanMetrics.enabled }}
   transform/spanmetrics:
     error_mode: silent
@@ -2411,8 +2253,130 @@ processors:
         {{- end}}
     {{- end }}
 {{- end }}
-{{- include "opentelemetry-collector.spanMetricsExtras.service" (dict "preset" .Values.presets.spanMetrics "transformProcessor" "transform/spanmetrics") }}
-{{- end -}}
+{{- if .Values.presets.spanMetrics.dbMetrics.transformStatements }}
+  transform/db:
+    error_mode: silent
+    trace_statements:
+      - context: span
+        statements:
+        {{- range $index, $pattern := .Values.presets.spanMetrics.dbMetrics.transformStatements }}
+        - {{ $pattern }}
+        {{- end}}
+{{- end }}
+{{- if .Values.presets.spanMetrics.compactMetrics.enabled }}
+  transform/compact:
+    trace_statements:
+      - context: resource
+        statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
+{{- end }}
+{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
+  transform/db_compact:
+    trace_statements:
+      - context: resource
+        statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
+      - context: span
+        statements:
+          - keep_keys(span.attributes, ["db.namespace", "db.system"])
+{{- end }}
+{{- if and (.Values.presets.spanMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.compactMetrics.dropHistogram) }}
+  transform/compact_histogram:
+    metric_statements:
+      - context: metric
+        statements:
+          - extract_sum_metric(false, ".sum") where metric.name == "compact.duration"
+          - extract_count_metric(false, ".count") where metric.name == "compact.duration"
+          - set(metric.unit, "") where metric.name == "compact.duration.sum"
+          - set(metric.unit, "") where metric.name == "compact.duration.count"
+          - set(metric.name, "compact.duration.ms.sum") where metric.name == "compact.duration.sum"
+          - set(metric.name, "compact.duration.ms.count") where metric.name == "compact.duration.count"
+  filter/drop_histogram:
+    metrics:
+      metric:
+        - 'metric.name == "compact.duration"'
+{{- end }}
+{{- if and (.Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.dbMetrics.compactMetrics.dropHistogram) }}
+  transform/db_compact_histogram:
+    metric_statements:
+      - context: metric
+        statements:
+          - extract_sum_metric(false, ".sum") where metric.name == "db_compact.duration"
+          - extract_count_metric(false, ".count") where metric.name == "db_compact.duration"
+          - set(metric.unit, "") where metric.name == "db_compact.duration.sum"
+          - set(metric.unit, "") where metric.name == "db_compact.duration.count"
+          - set(metric.name, "db_compact.duration.ms.sum") where metric.name == "db_compact.duration.sum"
+          - set(metric.name, "db_compact.duration.ms.count") where metric.name == "db_compact.duration.count"
+  filter/drop_db_compact_histogram:
+    metrics:
+      metric:
+        - 'metric.name == "db_compact.duration"'
+{{- end }}
+{{- if or (.Values.presets.spanMetrics.dbMetrics.enabled) (.Values.presets.spanMetrics.compactMetrics.enabled) (.Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled) }}
+service:
+  pipelines:
+{{- if .Values.presets.spanMetrics.dbMetrics.enabled }}
+    traces/db:
+      exporters:
+      - spanmetrics/db
+      processors:
+      - filter/db_spanmetrics
+      {{- if .Values.presets.spanMetrics.dbMetrics.transformStatements }}
+      - transform/db
+      {{- end }}
+      - batch
+      receivers:
+      - forward/db
+{{- end }}
+{{- if .Values.presets.spanMetrics.compactMetrics.enabled }}
+    traces/compact:
+      exporters:
+      - spanmetrics/compact
+      processors:
+      - transform/compact
+      - batch
+      receivers:
+      - forward/compact
+    metrics/compact:
+      receivers:
+      - spanmetrics/compact
+      processors:
+      - memory_limiter
+      - transform/spanmetrics
+      {{- if .Values.presets.spanMetrics.compactMetrics.dropHistogram }}
+      - transform/compact_histogram
+      - filter/drop_histogram
+      {{- end }}
+      - batch
+      exporters:
+      - coralogix
+{{- end }}
+{{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.enabled }}
+    traces/db_compact:
+      exporters:
+      - spanmetrics/db_compact
+      processors:
+      - filter/db_compact_spanmetrics
+      - transform/db_compact
+      - batch
+      receivers:
+      - forward/db_compact
+    metrics/db_compact:
+      receivers:
+      - spanmetrics/db_compact
+      processors:
+      - memory_limiter
+      - transform/spanmetrics
+      {{- if .Values.presets.spanMetrics.dbMetrics.compactMetrics.dropHistogram }}
+      - transform/db_compact_histogram
+      - filter/drop_db_compact_histogram
+      {{- end }}
+      - batch
+      exporters:
+      - coralogix
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{- define "opentelemetry-collector.spanMetricsMulti.extraDimensions" -}}
 {{- if .Values.presets.spanMetricsMulti.extraDimensions }}
@@ -2562,8 +2526,8 @@ connectors:
     {{- $extraDimensions | nindent 10 }}
     {{- end }}
   {{- end }}
-{{- include "opentelemetry-collector.spanMetricsExtras.connectors" (dict "preset" $sm "histogramBuckets" .Values.presets.spanMetricsMulti.defaultHistogramBuckets) }}
-{{- if or (include "opentelemetry-collector.spanMetricsExtrasEnabled" $sm) true }}
+{{- include "opentelemetry-collector.spanMetricsMultiExtras.connectors" (dict "preset" $sm "histogramBuckets" .Values.presets.spanMetricsMulti.defaultHistogramBuckets) }}
+{{- if or (include "opentelemetry-collector.spanMetricsMultiExtrasEnabled" $sm) true }}
 processors:
 {{- end }}
   transform/spanmetricsmulti:
@@ -2580,8 +2544,8 @@ processors:
         - {{ $pattern }}
         {{- end }}
     {{- end }}
-{{- include "opentelemetry-collector.spanMetricsExtras.processors" (dict "preset" $sm) }}
-{{- include "opentelemetry-collector.spanMetricsExtras.service" (dict "preset" $sm "transformProcessor" "transform/spanmetricsmulti") }}
+{{- include "opentelemetry-collector.spanMetricsMultiExtras.processors" (dict "preset" $sm) }}
+{{- include "opentelemetry-collector.spanMetricsMultiExtras.service" (dict "preset" $sm "transformProcessor" "transform/spanmetricsmulti") }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubernetesResourcesConfig" -}}
@@ -4493,6 +4457,272 @@ receivers:
 {{- $config | toYaml }}
 {{- end }}
 
+
+
+{{/* spanMetricsMulti optional db/compact/transform helpers (used only by spanMetricsMulti preset) */}}
+
+{{- define "opentelemetry-collector.spanMetricsMultiExtras.connectors" -}}
+{{- $p := .preset -}}
+{{- $histogramBuckets := .histogramBuckets -}}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
+{{- if $dbMetrics.enabled }}
+  spanmetrics/db:
+    namespace: "db"
+    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
+    dimensions:
+      - name: db.namespace
+      - name: db.operation.name
+      - name: db.collection.name
+      - name: db.system
+      {{- $dbServiceVersion := $dbMetrics.serviceVersion | default dict -}}
+      {{- if and $dbServiceVersion $dbServiceVersion.enabled }}
+      - name: service.version
+      {{- end }}
+      {{- if $dbMetrics.extraDimensions }}
+      {{- $dbMetrics.extraDimensions | toYaml | nindent 6 }}
+      {{- end }}
+{{- if $p.metricsExpiration }}
+    metrics_expiration: "{{ $p.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if $p.collectionInterval }}
+    metrics_flush_interval: "{{ $p.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+  forward/db: {}
+{{- end }}
+{{- if $compactMetrics.enabled }}
+  forward/compact: {}
+  spanmetrics/compact:
+    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    exclude_dimensions:
+    - span.name
+{{- if $histogramBuckets }}
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
+{{- end }}
+{{- if $p.metricsExpiration }}
+    metrics_expiration: "{{ $p.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if $p.collectionInterval }}
+    metrics_flush_interval: "{{ $p.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+    namespace: compact
+{{- end }}
+{{- if $dbCompactMetrics.enabled }}
+  forward/db_compact: {}
+  spanmetrics/db_compact:
+    aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
+    add_resource_attributes: true
+    dimensions:
+      - name: db.namespace
+      - name: db.system
+    exclude_dimensions:
+    - span.name
+    - span.kind
+{{- if $histogramBuckets }}
+    histogram:
+      unit: ms
+      explicit:
+        buckets: {{ $histogramBuckets | toYaml | nindent 12 }}
+{{- end }}
+{{- if $p.metricsExpiration }}
+    metrics_expiration: "{{ $p.metricsExpiration }}"
+{{- else }}
+    metrics_expiration: 0
+{{- end }}
+{{- if $p.collectionInterval }}
+    metrics_flush_interval: "{{ $p.collectionInterval }}"
+{{- else }}
+    metrics_flush_interval: 15s
+{{- end }}
+    namespace: db_compact
+{{- end }}
+{{- end -}}
+
+{{- define "opentelemetry-collector.spanMetricsMultiExtras.processors" -}}
+{{- $p := .preset -}}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
+{{- if and $p.spanNameReplacePattern (gt (len $p.spanNameReplacePattern) 0) }}
+  transform/span_name:
+    trace_statements:
+      - context: span
+        statements:
+        {{- range $index, $pattern := $p.spanNameReplacePattern }}
+        - replace_pattern(span.name, "{{ $pattern.regex }}", "{{ $pattern.replacement }}")
+        {{- end}}
+{{- end }}
+{{- if $dbMetrics.enabled }}
+  filter/db_spanmetrics:
+    traces:
+      span:
+        - 'span.attributes["db.system"] == nil'
+{{- end }}
+{{- if $dbCompactMetrics.enabled }}
+  filter/db_compact_spanmetrics:
+    traces:
+      span:
+        - 'span.kind != SPAN_KIND_CLIENT or span.attributes["db.namespace"] == nil or span.attributes["db.system"] == nil'
+{{- end }}
+{{- if and $dbMetrics.transformStatements (gt (len $dbMetrics.transformStatements) 0) }}
+  transform/db:
+    error_mode: silent
+    trace_statements:
+      - context: span
+        statements:
+        {{- range $index, $pattern := $dbMetrics.transformStatements }}
+        - {{ $pattern }}
+        {{- end}}
+{{- end }}
+{{- if $compactMetrics.enabled }}
+  transform/compact:
+    trace_statements:
+      - context: resource
+        statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
+{{- end }}
+{{- if $dbCompactMetrics.enabled }}
+  transform/db_compact:
+    trace_statements:
+      - context: resource
+        statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
+      - context: span
+        statements:
+          - keep_keys(span.attributes, ["db.namespace", "db.system"])
+{{- end }}
+{{- if and ($compactMetrics.enabled) ($compactMetrics.dropHistogram) }}
+  transform/compact_histogram:
+    metric_statements:
+      - context: metric
+        statements:
+          - extract_sum_metric(false, ".sum") where metric.name == "compact.duration"
+          - extract_count_metric(false, ".count") where metric.name == "compact.duration"
+          - set(metric.unit, "") where metric.name == "compact.duration.sum"
+          - set(metric.unit, "") where metric.name == "compact.duration.count"
+          - set(metric.name, "compact.duration.ms.sum") where metric.name == "compact.duration.sum"
+          - set(metric.name, "compact.duration.ms.count") where metric.name == "compact.duration.count"
+  filter/drop_histogram:
+    metrics:
+      metric:
+        - 'metric.name == "compact.duration"'
+{{- end }}
+{{- if and ($dbCompactMetrics.enabled) ($dbCompactMetrics.dropHistogram) }}
+  transform/db_compact_histogram:
+    metric_statements:
+      - context: metric
+        statements:
+          - extract_sum_metric(false, ".sum") where metric.name == "db_compact.duration"
+          - extract_count_metric(false, ".count") where metric.name == "db_compact.duration"
+          - set(metric.unit, "") where metric.name == "db_compact.duration.sum"
+          - set(metric.unit, "") where metric.name == "db_compact.duration.count"
+          - set(metric.name, "db_compact.duration.ms.sum") where metric.name == "db_compact.duration.sum"
+          - set(metric.name, "db_compact.duration.ms.count") where metric.name == "db_compact.duration.count"
+  filter/drop_db_compact_histogram:
+    metrics:
+      metric:
+        - 'metric.name == "db_compact.duration"'
+{{- end }}
+{{- end -}}
+
+{{- define "opentelemetry-collector.spanMetricsMultiExtras.service" -}}
+{{- $p := .preset -}}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
+{{- $transformProcessor := .transformProcessor -}}
+{{- $compactMetricsExporters := .compactMetricsExporters | default (list "coralogix") -}}
+{{- if or ($dbMetrics.enabled) ($compactMetrics.enabled) ($dbCompactMetrics.enabled) }}
+service:
+  pipelines:
+{{- if $dbMetrics.enabled }}
+    traces/db:
+      exporters:
+      - spanmetrics/db
+      processors:
+      - filter/db_spanmetrics
+      {{- if and $dbMetrics.transformStatements (gt (len $dbMetrics.transformStatements) 0) }}
+      - transform/db
+      {{- end }}
+      - batch
+      receivers:
+      - forward/db
+{{- end }}
+{{- if $compactMetrics.enabled }}
+    traces/compact:
+      exporters:
+      - spanmetrics/compact
+      processors:
+      - transform/compact
+      - batch
+      receivers:
+      - forward/compact
+    metrics/compact:
+      receivers:
+      - spanmetrics/compact
+      processors:
+      - memory_limiter
+      - {{ $transformProcessor }}
+      {{- if $compactMetrics.dropHistogram }}
+      - transform/compact_histogram
+      - filter/drop_histogram
+      {{- end }}
+      - batch
+      exporters:
+      {{- $compactMetricsExporters | toYaml | nindent 6 }}
+{{- end }}
+{{- if $dbCompactMetrics.enabled }}
+    traces/db_compact:
+      exporters:
+      - spanmetrics/db_compact
+      processors:
+      - filter/db_compact_spanmetrics
+      - transform/db_compact
+      - batch
+      receivers:
+      - forward/db_compact
+    metrics/db_compact:
+      receivers:
+      - spanmetrics/db_compact
+      processors:
+      - memory_limiter
+      - {{ $transformProcessor }}
+      {{- if $dbCompactMetrics.dropHistogram }}
+      - transform/db_compact_histogram
+      - filter/drop_db_compact_histogram
+      {{- end }}
+      - batch
+      exporters:
+      {{- $compactMetricsExporters | toYaml | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "opentelemetry-collector.spanMetricsMultiExtrasEnabled" -}}
+{{- $p := . -}}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
+{{- or (and $p.spanNameReplacePattern (gt (len $p.spanNameReplacePattern) 0)) ($dbMetrics.enabled) (and $p.transformStatements (gt (len $p.transformStatements) 0)) ($compactMetrics.enabled) ($dbCompactMetrics.enabled) -}}
+{{- end -}}
 
 {{- define "opentelemetry-collector.spanMetricsSanitizationConfig" -}}
 processors:

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -2108,7 +2108,10 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
 {{- define "opentelemetry-collector.spanMetricsExtras.connectors" -}}
 {{- $p := .preset -}}
 {{- $histogramBuckets := .histogramBuckets -}}
-{{- if $p.dbMetrics.enabled }}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
+{{- if $dbMetrics.enabled }}
   spanmetrics/db:
     namespace: "db"
     aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
@@ -2122,11 +2125,12 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
       - name: db.operation.name
       - name: db.collection.name
       - name: db.system
-      {{- if $p.dbMetrics.serviceVersion.enabled }}
+      {{- $dbServiceVersion := $dbMetrics.serviceVersion | default dict -}}
+      {{- if and $dbServiceVersion $dbServiceVersion.enabled }}
       - name: service.version
       {{- end }}
-      {{- if $p.dbMetrics.extraDimensions }}
-      {{- $p.dbMetrics.extraDimensions | toYaml | nindent 6 }}
+      {{- if $dbMetrics.extraDimensions }}
+      {{- $dbMetrics.extraDimensions | toYaml | nindent 6 }}
       {{- end }}
 {{- if $p.metricsExpiration }}
     metrics_expiration: "{{ $p.metricsExpiration }}"
@@ -2140,7 +2144,7 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
 {{- end }}
   forward/db: {}
 {{- end }}
-{{- if $p.compactMetrics.enabled }}
+{{- if $compactMetrics.enabled }}
   forward/compact: {}
   spanmetrics/compact:
     aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
@@ -2165,7 +2169,7 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
 {{- end }}
     namespace: compact
 {{- end }}
-{{- if $p.dbMetrics.compactMetrics.enabled }}
+{{- if $dbCompactMetrics.enabled }}
   forward/db_compact: {}
   spanmetrics/db_compact:
     aggregation_cardinality_limit: {{ $p.aggregationCardinalityLimit }}
@@ -2198,7 +2202,10 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
 
 {{- define "opentelemetry-collector.spanMetricsExtras.processors" -}}
 {{- $p := .preset -}}
-{{- if $p.spanNameReplacePattern }}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
+{{- if and $p.spanNameReplacePattern (gt (len $p.spanNameReplacePattern) 0) }}
   transform/span_name:
     trace_statements:
       - context: span
@@ -2207,36 +2214,36 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
         - replace_pattern(span.name, "{{ $pattern.regex }}", "{{ $pattern.replacement }}")
         {{- end}}
 {{- end }}
-{{- if $p.dbMetrics.enabled }}
+{{- if $dbMetrics.enabled }}
   filter/db_spanmetrics:
     traces:
       span:
         - 'attributes["db.system"] == nil'
 {{- end }}
-{{- if $p.dbMetrics.compactMetrics.enabled }}
+{{- if $dbCompactMetrics.enabled }}
   filter/db_compact_spanmetrics:
     traces:
       span:
         - 'kind != SPAN_KIND_CLIENT or attributes["db.namespace"] == nil or attributes["db.system"] == nil'
 {{- end }}
-{{- if $p.dbMetrics.transformStatements }}
+{{- if and $dbMetrics.transformStatements (gt (len $dbMetrics.transformStatements) 0) }}
   transform/db:
     error_mode: silent
     trace_statements:
       - context: span
         statements:
-        {{- range $index, $pattern := $p.dbMetrics.transformStatements }}
+        {{- range $index, $pattern := $dbMetrics.transformStatements }}
         - {{ $pattern }}
         {{- end}}
 {{- end }}
-{{- if $p.compactMetrics.enabled }}
+{{- if $compactMetrics.enabled }}
   transform/compact:
     trace_statements:
       - context: resource
         statements:
           - keep_keys(attributes, ["service.name", "k8s.cluster.name", "host.name", "deployment.environment.name"])
 {{- end }}
-{{- if $p.dbMetrics.compactMetrics.enabled }}
+{{- if $dbCompactMetrics.enabled }}
   transform/db_compact:
     trace_statements:
       - context: resource
@@ -2246,7 +2253,7 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
         statements:
           - keep_keys(attributes, ["db.namespace", "db.system"])
 {{- end }}
-{{- if and ($p.compactMetrics.enabled) ($p.compactMetrics.dropHistogram) }}
+{{- if and ($compactMetrics.enabled) ($compactMetrics.dropHistogram) }}
   transform/compact_histogram:
     metric_statements:
       - context: metric
@@ -2262,7 +2269,7 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
       metric:
         - 'name == "compact.duration"'
 {{- end }}
-{{- if and ($p.dbMetrics.compactMetrics.enabled) ($p.dbMetrics.compactMetrics.dropHistogram) }}
+{{- if and ($dbCompactMetrics.enabled) ($dbCompactMetrics.dropHistogram) }}
   transform/db_compact_histogram:
     metric_statements:
       - context: metric
@@ -2282,25 +2289,28 @@ cx.integrationID: "{{ .Values.presets.fleetManagement.integrationID }}"
 
 {{- define "opentelemetry-collector.spanMetricsExtras.service" -}}
 {{- $p := .preset -}}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
 {{- $transformProcessor := .transformProcessor -}}
 {{- $compactMetricsExporters := .compactMetricsExporters | default (list "coralogix") -}}
-{{- if or ($p.dbMetrics.enabled) ($p.compactMetrics.enabled) ($p.dbMetrics.compactMetrics.enabled) }}
+{{- if or ($dbMetrics.enabled) ($compactMetrics.enabled) ($dbCompactMetrics.enabled) }}
 service:
   pipelines:
-{{- if $p.dbMetrics.enabled }}
+{{- if $dbMetrics.enabled }}
     traces/db:
       exporters:
       - spanmetrics/db
       processors:
       - filter/db_spanmetrics
-      {{- if $p.dbMetrics.transformStatements }}
+      {{- if and $dbMetrics.transformStatements (gt (len $dbMetrics.transformStatements) 0) }}
       - transform/db
       {{- end }}
       - batch
       receivers:
       - forward/db
 {{- end }}
-{{- if $p.compactMetrics.enabled }}
+{{- if $compactMetrics.enabled }}
     traces/compact:
       exporters:
       - spanmetrics/compact
@@ -2315,7 +2325,7 @@ service:
       processors:
       - memory_limiter
       - {{ $transformProcessor }}
-      {{- if $p.compactMetrics.dropHistogram }}
+      {{- if $compactMetrics.dropHistogram }}
       - transform/compact_histogram
       - filter/drop_histogram
       {{- end }}
@@ -2323,7 +2333,7 @@ service:
       exporters:
       {{- $compactMetricsExporters | toYaml | nindent 6 }}
 {{- end }}
-{{- if $p.dbMetrics.compactMetrics.enabled }}
+{{- if $dbCompactMetrics.enabled }}
     traces/db_compact:
       exporters:
       - spanmetrics/db_compact
@@ -2339,7 +2349,7 @@ service:
       processors:
       - memory_limiter
       - {{ $transformProcessor }}
-      {{- if $p.dbMetrics.compactMetrics.dropHistogram }}
+      {{- if $dbCompactMetrics.dropHistogram }}
       - transform/db_compact_histogram
       - filter/drop_db_compact_histogram
       {{- end }}
@@ -2352,7 +2362,10 @@ service:
 
 {{- define "opentelemetry-collector.spanMetricsExtrasEnabled" -}}
 {{- $p := . -}}
-{{- or ($p.spanNameReplacePattern) ($p.dbMetrics.enabled) ($p.transformStatements) ($p.compactMetrics.enabled) ($p.dbMetrics.compactMetrics.enabled) -}}
+{{- $dbMetrics := $p.dbMetrics | default dict -}}
+{{- $compactMetrics := $p.compactMetrics | default dict -}}
+{{- $dbCompactMetrics := $dbMetrics.compactMetrics | default dict -}}
+{{- or (and $p.spanNameReplacePattern (gt (len $p.spanNameReplacePattern) 0)) ($dbMetrics.enabled) (and $p.transformStatements (gt (len $p.transformStatements) 0)) ($compactMetrics.enabled) ($dbCompactMetrics.enabled) -}}
 {{- end -}}
 
 {{- define "opentelemetry-collector.spanMetricsConfig" -}}
@@ -2414,17 +2427,26 @@ processors:
 {{- if .Values.presets.spanMetricsMulti.extraDimensions }}
 {{- .Values.presets.spanMetricsMulti.extraDimensions | toYaml }}
 {{- end }}
-{{- if .Values.presets.spanMetricsMulti.errorTracking.enabled }}
+{{- $multiErrorTracking := .Values.presets.spanMetricsMulti.errorTracking -}}
+{{- if and $multiErrorTracking (hasKey $multiErrorTracking "enabled") -}}
+{{- if $multiErrorTracking.enabled }}
 - name: http.response.status_code
 - name: rpc.grpc.status_code
 {{- end }}
-{{- if .Values.presets.spanMetricsMulti.serviceVersion.enabled }}
+{{- else if .Values.presets.spanMetrics.errorTracking.enabled }}
+- name: http.response.status_code
+- name: rpc.grpc.status_code
+{{- end }}
+{{- $multiServiceVersion := .Values.presets.spanMetricsMulti.serviceVersion -}}
+{{- if and $multiServiceVersion $multiServiceVersion.enabled }}
 - name: service.version
 {{- end }}
 {{- end}}
 
 {{- define "opentelemetry-collector.applySpanMetricsMultiConfig" -}}
-{{- $sm := .Values.Values.presets.spanMetricsMulti }}
+{{- $sm := merge (dict "dbMetrics" (dict "enabled" false "compactMetrics" (dict "enabled" false)) "compactMetrics" (dict "enabled" false)) .Values.Values.presets.spanMetricsMulti }}
+{{- $hasTransformStatements := and $sm.transformStatements (gt (len $sm.transformStatements) 0) }}
+{{- $hasSpanNameReplacePattern := and $sm.spanNameReplacePattern (gt (len $sm.spanNameReplacePattern) 0) }}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.spanMetricsMultiConfig" .Values | fromYaml) .config }}
 {{- $tracesPipeline := deepCopy $config.service.pipelines.traces }}
 {{- $_ := set $tracesPipeline "processors" (list "batch") }}
@@ -2450,12 +2472,12 @@ processors:
 {{- $tracesExporters = append $tracesExporters "forward/db_compact" | uniq }}
 {{- end }}
 {{- $_ := set $config.service.pipelines.traces "exporters" $tracesExporters }}
-{{- if $sm.transformStatements }}
+{{- if $hasTransformStatements }}
 {{- if not (has "transform/spanmetricsmulti" $config.service.pipelines.traces.processors) }}
 {{- $_ := set $config.service.pipelines.traces "processors" (append $config.service.pipelines.traces.processors "transform/spanmetricsmulti" | uniq) }}
 {{- end }}
 {{- end }}
-{{- if $sm.spanNameReplacePattern }}
+{{- if $hasSpanNameReplacePattern }}
 {{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors "transform/span_name" | uniq) }}
 {{- end }}
 {{- end }}
@@ -2484,6 +2506,7 @@ processors:
 {{- end }}
 
 {{- define "opentelemetry-collector.spanMetricsMultiConfig" -}}
+{{- $sm := merge (dict "dbMetrics" (dict "enabled" false "compactMetrics" (dict "enabled" false)) "compactMetrics" (dict "enabled" false)) .Values.presets.spanMetricsMulti }}
 connectors:
   routing:
     default_pipelines: [traces/default]
@@ -2496,6 +2519,8 @@ connectors:
   spanmetrics/default:
 {{- if .Values.presets.spanMetricsMulti.namespace }}
     namespace: "{{ .Values.presets.spanMetricsMulti.namespace }}"
+{{- else if .Values.presets.spanMetrics.namespace }}
+    namespace: "{{ .Values.presets.spanMetrics.namespace }}"
 {{- else }}
     namespace: ""
 {{- end }}
@@ -2540,14 +2565,13 @@ connectors:
     {{- else }}
     metrics_expiration: 0
     {{- end }}
-    {{- $extraDimensions := include "opentelemetry-collector.spanMetricsMulti.extraDimensions" $root }}
-    {{- if and $extraDimensions (gt (len $extraDimensions) 0) }}
+    {{- if $root.Values.presets.spanMetricsMulti.extraDimensions }}
     dimensions:
-    {{- $extraDimensions | nindent 10 }}
+    {{- $root.Values.presets.spanMetricsMulti.extraDimensions | toYaml | nindent 10 }}
     {{- end }}
   {{- end }}
-{{- include "opentelemetry-collector.spanMetricsExtras.connectors" (dict "preset" .Values.presets.spanMetricsMulti "histogramBuckets" .Values.presets.spanMetricsMulti.defaultHistogramBuckets) }}
-{{- if or (include "opentelemetry-collector.spanMetricsExtrasEnabled" .Values.presets.spanMetricsMulti) true }}
+{{- include "opentelemetry-collector.spanMetricsExtras.connectors" (dict "preset" $sm "histogramBuckets" .Values.presets.spanMetricsMulti.defaultHistogramBuckets) }}
+{{- if or (include "opentelemetry-collector.spanMetricsExtrasEnabled" $sm) true }}
 processors:
 {{- end }}
   transform/spanmetricsmulti:
@@ -2556,7 +2580,7 @@ processors:
       - context: datapoint
         statements:
         {{- include "opentelemetry-collector.spanMetricsStatusCodeStatements" . | nindent 8 }}
-    {{- if .Values.presets.spanMetricsMulti.transformStatements }}
+    {{- if and .Values.presets.spanMetricsMulti.transformStatements (gt (len .Values.presets.spanMetricsMulti.transformStatements) 0) }}
     trace_statements:
       - context: span
         statements:
@@ -2564,8 +2588,8 @@ processors:
         - {{ $pattern }}
         {{- end }}
     {{- end }}
-{{- include "opentelemetry-collector.spanMetricsExtras.processors" (dict "preset" .Values.presets.spanMetricsMulti) }}
-{{- include "opentelemetry-collector.spanMetricsExtras.service" (dict "preset" .Values.presets.spanMetricsMulti "transformProcessor" "transform/spanmetricsmulti") }}
+{{- include "opentelemetry-collector.spanMetricsExtras.processors" (dict "preset" $sm) }}
+{{- include "opentelemetry-collector.spanMetricsExtras.service" (dict "preset" $sm "transformProcessor" "transform/spanmetricsmulti") }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubernetesResourcesConfig" -}}

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -1125,6 +1125,90 @@
               "description": "Specifies whether the collector should configure span metrics connector.",
               "type": "boolean"
             },
+            "transformStatements": {
+              "description": "Specifies additional transform statements.",
+              "type": "array"
+            },
+            "serviceVersion": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "description": "Specifies whether the collector should add service.version dimension.",
+                  "type": "boolean"
+                }
+              }
+            },
+            "dbMetrics": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "description": "Specifies whether the collector should configure spanmetrics metrics connector for db spans.",
+                  "type": "boolean"
+                },
+                "serviceVersion": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "description": "Specifies whether the collector should add service.version dimension.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "transformStatements": {
+                  "description": "Specifies additional transform statements.",
+                  "type": "array"
+                },
+                "extraDimensions": {
+                  "description": "Specifies additional dimensions for db metrics.",
+                  "type": "array"
+                },
+                "compactMetrics": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "description": "Specifies whether the collector should configure compact metrics for db spans.",
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "dropHistogram": {
+                      "description": "Specifies whether to drop histogram metrics and keep only sum and count.",
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
+                }
+              }
+            },
+            "compactMetrics": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "description": "Specifies whether the collector should configure compact spanmetrics pipeline.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "dropHistogram": {
+                  "description": "Specifies whether to drop the original compact duration histogram after extracting sum and count metrics.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "errorTracking": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "description": "Specifies whether to enable error tracking.",
+                  "type": "boolean"
+                }
+              }
+            },
             "namespace": {
               "description": "Defines the namespace of the generated metrics. If namespace provided, generated metric name will be added namespace. prefix.",
               "type": "string"
@@ -1144,6 +1228,23 @@
             "extraDimensions": {
               "description": "Specifies additional dimensions for span metrics.",
               "type": "array"
+            },
+            "spanNameReplacePattern": {
+              "description": "Configures a regex pattern to replace the span name.",
+              "additionalProperties": false,
+              "type": "array",
+              "items": {
+                "properties": {
+                  "regex": {
+                    "description": "Regex pattern to match against the span name.",
+                    "type": "string"
+                  },
+                  "replacement": {
+                    "description": "Value to replace the span with.",
+                    "type": "string"
+                  }
+                }
+              }
             },
             "configs": {
               "description": "Specifies the config for buckets.",

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -446,6 +446,21 @@ presets:
   # using OTTL. For more information see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector
   spanMetricsMulti:
     enabled: false
+    serviceVersion:
+      enabled: true
+    dbMetrics:
+      enabled: false
+      serviceVersion:
+        enabled: true
+      extraDimensions: []
+      compactMetrics:
+        enabled: false
+        dropHistogram: false
+    compactMetrics:
+      enabled: false
+      dropHistogram: false
+    errorTracking:
+      enabled: true
     extraDimensions:
       - name: http.method
       - name: cgx.transaction
@@ -457,6 +472,8 @@ presets:
       - name: db.system
     defaultHistogramBuckets:
       [1ms, 4ms, 10ms, 20ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s]
+    transformStatements: []
+    spanNameReplacePattern: []
     # collectionInterval: 30s
     # metricsExpiration: 5m
     aggregationCardinalityLimit: 100000

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -446,21 +446,14 @@ presets:
   # using OTTL. For more information see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector
   spanMetricsMulti:
     enabled: false
-    serviceVersion:
-      enabled: true
-    dbMetrics:
-      enabled: false
-      serviceVersion:
-        enabled: true
-      extraDimensions: []
-      compactMetrics:
-        enabled: false
-        dropHistogram: false
-    compactMetrics:
-      enabled: false
-      dropHistogram: false
-    errorTracking:
-      enabled: true
+    # Optional: same knobs as spanMetrics preset. Omitted by default so upgrades keep existing behavior.
+    # serviceVersion:
+    #   enabled: false
+    # errorTracking uses presets.spanMetrics.errorTracking when spanMetricsMulti.errorTracking is unset.
+    # dbMetrics:
+    #   enabled: false
+    # compactMetrics:
+    #   enabled: false
     extraDimensions:
       - name: http.method
       - name: cgx.transaction
@@ -472,8 +465,6 @@ presets:
       - name: db.system
     defaultHistogramBuckets:
       [1ms, 4ms, 10ms, 20ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s]
-    transformStatements: []
-    spanNameReplacePattern: []
     # collectionInterval: 30s
     # metricsExpiration: 5m
     aggregationCardinalityLimit: 100000


### PR DESCRIPTION
Solves CDS-2986. Customers using `presets.spanMetricsMulti` could not configure `transformStatements`, `spanNameReplacePattern`, `dbMetrics`, or `compactMetrics` — options that already exist on `presets.spanMetrics.`

This PR adds full parity for those options on `spanMetricsMulti`, so teams can combine per-service histogram routing with cardinality control, DB-focused metrics, and compact metrics without hand-writing large `extraConfig` blocks.

Added `ci/preset-spanMetricsMultiExtras-values.yaml` — installs Multi with all new options enabled