### PR TITLE
fix(clusterrole-targetallocator): add watch verb to secrets permission

### DIFF
--- a/charts/opentelemetry-collector/templates/clusterrole-targetallocator.yaml
+++ b/charts/opentelemetry-collector/templates/clusterrole-targetallocator.yaml
@@ -46,7 +46,7 @@ rules:
     verbs: ['*']
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   {{- end}}
 
 {{- end }}


### PR DESCRIPTION
## Problem

When `prometheusCR.enabled: true`, the target allocator watches secrets to resolve authentication references (TLS certs, bearer tokens) in ServiceMonitor/PodMonitor/Probe scrape configs. However, the ClusterRole only granted `get` and `list` on secrets — not `watch` — causing repeated errors in the TA logs:

\`\`\`
Failed to watch *v1.PartialObjectMetadata: secrets is forbidden:
User "system:serviceaccount:<ns>:<sa>" cannot watch resource "secrets"
in API group "" in the namespace "<ns>"
\`\`\`

## Fix

Add `watch` to the secrets verb list to match the actual access pattern used by the TA.

## Testing

Verified the TA no longer logs the `Failed to watch secrets` error after applying this fix.