### PR TITLE
Add stat metrics support

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+++ b/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry eBPF Instrumentation
 
+### v0.1.17 / 2026-06-08
+
+- [Feature] Add Stat metrics option to OBI config, defaults false
+
 ### v0.1.16 / 2026-05-14
 
 - [Chore] Bump version to v0.1.15.

--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.1.16
+version: 0.1.17
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-ebpf-instrumentation/templates/daemon-set.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/daemon-set.yaml
@@ -127,6 +127,11 @@ spec:
             - mountPath: /sys/fs/cgroup
               name: cgroup
           {{- end }}
+          {{- if .Values.stats.enabled }}
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
+              readOnly: true
+          {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -158,6 +163,12 @@ spec:
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
+      {{- end }}
+      {{- if .Values.stats.enabled }}
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+            type: Directory
       {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -61,6 +61,10 @@ podSecurityContext: {}
 # -- If set to false, deploys an unprivileged / less privileged setup.
 privileged: true
 
+# -- Enables stat metrics support (requires tracefs mount).
+stats:
+  enabled: false
+
 # -- Enables context propagation support.
 contextPropagation:
   enabled: true


### PR DESCRIPTION
This PR adds a new `stats.enabled` value (default `false`) that mounts `/sys/kernel/tracing` into the DaemonSet when enabled. Used to enable stat metrics (tcp rtt, tcp failed connections and so on).