### PR TITLE
Bump obi to `0.10.0` with new default configs and minor fixes

### DIFF
--- a/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+++ b/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## OpenTelemetry eBPF Instrumentation
 
+### v0.1.18 / 2026-07-01
+
+- [Change] Bump OBI image to v0.10.0
+- [Fix] Update default `contextPropagation.mode` from "http,tcp" to "headers,tcp" (the "http" alias was removed upstream and now causes a startup error)
+- [Fix] Fix typo in default config: `payload_extraction.http.genai.rerank` (was `rereank`)
+- [Feature] Add `runtimeMetrics.go.enabled` and `runtimeMetrics.jvm.enabled` options (both default `false`) to opt in to the new Go and JVM application runtime metrics
+- [Feature] Add `health_check.port` (default `0`/disabled) to the default OBI config to surface the new pipeline health-check endpoint
+- [Fix] `stats.enabled: true` now also adds the "stats" metrics feature to `otel_metrics_export.features`; previously it only mounted tracefs, so stat probes loaded as no-op stubs and no stats metrics were ever exported
+
 ### v0.1.17 / 2026-06-08
 
 - [Feature] Add Stat metrics option to OBI config, defaults false

--- a/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+++ b/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
@@ -10,6 +10,8 @@
 - [Feature] Add `runtimeMetrics.go.enabled` and `runtimeMetrics.jvm.enabled` options (both default `false`) to opt in to the new Go and JVM application runtime metrics
 - [Feature] Add `health_check.port` (default `0`/disabled) to the default OBI config to surface the new pipeline health-check endpoint
 - [Fix] `stats.enabled: true` now also adds the "stats" metrics feature to `otel_metrics_export.features`; previously it only mounted tracefs, so stat probes loaded as no-op stubs and no stats metrics were ever exported
+- [Fix] Migrate default discovery config from deprecated `services`/`exclude_services` to `instrument`/`exclude_instrument` with glob syntax
+- [Fix] Fix default `k8s_namespace` pattern from `.` (matches any single character) to `".*"` (matches any namespace)
 
 ### v0.1.17 / 2026-06-08
 

--- a/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+++ b/charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [Feature] Add `health_check.port` (default `0`/disabled) to the default OBI config to surface the new pipeline health-check endpoint
 - [Fix] `stats.enabled: true` now also adds the "stats" metrics feature to `otel_metrics_export.features`; previously it only mounted tracefs, so stat probes loaded as no-op stubs and no stats metrics were ever exported
 - [Fix] Migrate default discovery config from deprecated `services`/`exclude_services` to `instrument`/`exclude_instrument` with glob syntax
-- [Fix] Fix default `k8s_namespace` pattern from `.` (matches any single character) to `".*"` (matches any namespace)
+- [Fix] Fix default `k8s_namespace` pattern from `.` (matches any single character) to `"*"` (glob for any namespace)
 
 ### v0.1.17 / 2026-06-08
 

--- a/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: opentelemetry-ebpf-instrumentation
-version: 0.1.17
+version: 0.1.18
 description: OpenTelemetry eBPF instrumentation Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/
@@ -11,4 +11,4 @@ sources:
 icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 maintainers:
   - name: nimrodavni78
-appVersion: v0.9.0
+appVersion: v0.10.0

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cache-deployment.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cache-deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: obi
     app.kubernetes.io/component: workload
@@ -21,17 +21,17 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v0.9.0"
+        app.kubernetes.io/version: "v0.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: obi
     spec:
       serviceAccountName: example-opentelemetry-ebpf-instrumentation
       containers:
         - name: obi-k8s-cache
-          image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-k8s-cache:v0.9.0
+          image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-k8s-cache:v0.10.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 50055

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cache-service.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cache-service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: opentelemetry-ebpf-instrumentation-k8s-cache
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation-k8s-cache
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: obi
     app.kubernetes.io/component: networking

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cluster-role-binding.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cluster-role-binding.yaml
@@ -5,10 +5,10 @@ kind: ClusterRoleBinding
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: obi
     app.kubernetes.io/component: rbac

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cluster-role.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/cluster-role.yaml
@@ -5,10 +5,10 @@ kind: ClusterRole
 metadata:
   name: example-opentelemetry-ebpf-instrumentation
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: obi
     app.kubernetes.io/component: rbac

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: obi
     app.kubernetes.io/component: config
@@ -52,7 +52,7 @@ data:
               enabled: true
             qwen:
               enabled: true
-            rereank:
+            rerank:
               enabled: true
             retrieval:
               enabled: true
@@ -70,6 +70,8 @@ data:
           not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
         k8s_src_owner_name:
           not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+    health_check:
+      port: 0
     otel_metrics_export:
       endpoint: http://${HOST_IP}:4318
     otel_traces_export:

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/configmap.yaml
@@ -16,10 +16,11 @@ metadata:
 data:
   ebpf-instrument-config.yml: |
     discovery:
-      services:
-        - k8s_namespace: .
-      exclude_services:
-        - exe_path: ".*ebpf-instrument.*|.*otelcol.*"
+      instrument:
+        - k8s_namespace: ".*"
+      exclude_instrument:
+        - exe_path: "*ebpf-instrument*"
+        - exe_path: "*otelcol*"
     attributes:
       kubernetes:
         enable: true

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/configmap.yaml
@@ -17,7 +17,7 @@ data:
   ebpf-instrument-config.yml: |
     discovery:
       instrument:
-        - k8s_namespace: ".*"
+        - k8s_namespace: "*"
       exclude_instrument:
         - exe_path: "*ebpf-instrument*"
         - exe_path: "*otelcol*"

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/daemon-set.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/daemon-set.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: obi
     app.kubernetes.io/component: workload
@@ -23,12 +23,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c4c877234c1bfa84494edfecd7329bfe653ed9bb125a3622d8d827eb58609a94
+        checksum/config: 8fe65c72eb3768dc98ebe1bd6650622773b1cf26f4e29cc9bd9b3a351b2fa1a9
       labels:
-        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+        helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
         app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
         app.kubernetes.io/instance: example
-        app.kubernetes.io/version: "v0.9.0"
+        app.kubernetes.io/version: "v0.10.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: obi
         app.kubernetes.io/component: workload
@@ -40,7 +40,7 @@ spec:
       initContainers:
       containers:
         - name: ebpf-instrument
-          image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.9.0
+          image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.10.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -59,7 +59,7 @@ spec:
             - name: OTEL_EBPF_KUBE_META_CACHE_ADDRESS
               value: opentelemetry-ebpf-instrumentation-k8s-cache:50055
             - name: OTEL_EBPF_BPF_CONTEXT_PROPAGATION
-              value: "http,tcp"
+              value: "headers,tcp"
           volumeMounts:
             - mountPath: /etc/ebpf-instrument/config
               name: ebpf-instrument-config

--- a/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/examples/ebpf-instrumentation/rendered/serviceaccount.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-opentelemetry-ebpf-instrumentation
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.16
+    helm.sh/chart: opentelemetry-ebpf-instrumentation-0.1.18
     app.kubernetes.io/name: opentelemetry-ebpf-instrumentation
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.10.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: obi
     app.kubernetes.io/component: rbac

--- a/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
@@ -27,24 +27,24 @@ data:
     {{- if eq .Values.preset "application" }}
     {{- if not .Values.config.data.discovery }}
     discovery:
-      services:
-        - k8s_namespace: .
-      exclude_services:
-        - exe_path: ".*ebpf-instrument.*|.*otelcol.*"
+      instrument:
+        - k8s_namespace: ".*"
+      exclude_instrument:
+        - exe_path: "*ebpf-instrument*"
+        - exe_path: "*otelcol*"
     {{- end }}
     {{- end }}
   {{- $configData := deepCopy .Values.config.data }}
   {{- if or .Values.runtimeMetrics.go.enabled .Values.runtimeMetrics.jvm.enabled .Values.stats.enabled }}
-    {{- $otelMetricsExport := default dict $configData.otel_metrics_export }}
-    {{- $features := index $otelMetricsExport "features" }}
-    {{- if not $features }}
-      {{- $features = list "application" }}
+    {{- if not (hasKey $configData "otel_metrics_export") }}
+      {{- $_ := set $configData "otel_metrics_export" dict }}
     {{- end }}
+    {{- $otelMetricsExport := index $configData "otel_metrics_export" }}
+    {{- $features := index $otelMetricsExport "features" | default list }}
     {{- if and .Values.runtimeMetrics.go.enabled (not (has "application_runtime" $features)) }}{{ $features = append $features "application_runtime" }}{{- end }}
     {{- if and .Values.runtimeMetrics.jvm.enabled (not (has "application_jvm" $features)) }}{{ $features = append $features "application_jvm" }}{{- end }}
     {{- if and .Values.stats.enabled (not (has "stats" $features)) }}{{ $features = append $features "stats" }}{{- end }}
     {{- $_ := set $otelMetricsExport "features" $features }}
-    {{- $_ := set $configData "otel_metrics_export" $otelMetricsExport }}
   {{- end }}
   {{- if .Values.runtimeMetrics.jvm.enabled }}
     {{- if not (hasKey $configData "jvm_runtime_metrics") }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
@@ -33,5 +33,23 @@ data:
         - exe_path: ".*ebpf-instrument.*|.*otelcol.*"
     {{- end }}
     {{- end }}
-  {{- toYaml .Values.config.data | nindent 4}}
+  {{- $configData := deepCopy .Values.config.data }}
+  {{- if or .Values.runtimeMetrics.go.enabled .Values.runtimeMetrics.jvm.enabled .Values.stats.enabled }}
+    {{- $otelMetricsExport := default dict $configData.otel_metrics_export }}
+    {{- $features := index $otelMetricsExport "features" }}
+    {{- if not $features }}
+      {{- $features = list "application" }}
+    {{- end }}
+    {{- if and .Values.runtimeMetrics.go.enabled (not (has "application_runtime" $features)) }}{{ $features = append $features "application_runtime" }}{{- end }}
+    {{- if and .Values.runtimeMetrics.jvm.enabled (not (has "application_jvm" $features)) }}{{ $features = append $features "application_jvm" }}{{- end }}
+    {{- if and .Values.stats.enabled (not (has "stats" $features)) }}{{ $features = append $features "stats" }}{{- end }}
+    {{- $_ := set $otelMetricsExport "features" $features }}
+    {{- $_ := set $configData "otel_metrics_export" $otelMetricsExport }}
+  {{- end }}
+  {{- if .Values.runtimeMetrics.jvm.enabled }}
+    {{- if not (hasKey $configData "jvm_runtime_metrics") }}
+      {{- $_ := set $configData "jvm_runtime_metrics" (dict "enabled" true "sampling_interval" .Values.runtimeMetrics.jvm.samplingInterval) }}
+    {{- end }}
+  {{- end }}
+  {{- toYaml $configData | nindent 4}}
 {{- end }}

--- a/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
     {{- if not .Values.config.data.discovery }}
     discovery:
       instrument:
-        - k8s_namespace: ".*"
+        - k8s_namespace: "*"
       exclude_instrument:
         - exe_path: "*ebpf-instrument*"
         - exe_path: "*otelcol*"

--- a/charts/opentelemetry-ebpf-instrumentation/values.yaml
+++ b/charts/opentelemetry-ebpf-instrumentation/values.yaml
@@ -61,15 +61,32 @@ podSecurityContext: {}
 # -- If set to false, deploys an unprivileged / less privileged setup.
 privileged: true
 
-# -- Enables stat metrics support (requires tracefs mount).
+# -- Enables stat metrics support (requires tracefs mount). Adds "stats" (tcp_rtt,
+# tcp_failed_connections, tcp_retransmits, tcp_io) to the exported metrics features.
+# Note: tcp_io fires on every tcp_sendmsg/tcp_cleanup_rbuf call, so it has significantly
+# higher event volume/overhead than the other three stat metrics.
 stats:
   enabled: false
+
+# -- Enables collection of application runtime metrics (memory, GC, etc). Both are disabled by
+# default since they add eBPF uprobe/USDT instrumentation overhead.
+runtimeMetrics:
+  go:
+    # -- Enables Go runtime metrics (memory limits, completed GC cycles, GOMAXPROCS, GOGC).
+    # Adds "application_runtime" to the exported metrics features.
+    enabled: false
+  jvm:
+    # -- Enables HotSpot JVM runtime metrics (heap used/committed/limit) via GCTracer uprobe and
+    # USDT probes. Adds "application_jvm" to the exported metrics features.
+    enabled: false
+    # -- (string) Sampling interval for JVM runtime metrics collection.
+    samplingInterval: 1s
 
 # -- Enables context propagation support.
 contextPropagation:
   enabled: true
-  # -- Mode of context propagation: either "all" or a list containing the following values: "http", "headers", "tcp", "ip
-  mode: "http,tcp"
+  # -- Mode of context propagation: either "all", "disabled", or a comma-separated list containing the following values: "headers", "tcp"
+  mode: "headers,tcp"
 
 # -- Extra capabilities for unprivileged / less privileged setup.
 extraCapabilities: []
@@ -243,7 +260,7 @@ config:
               enabled: true
             qwen:
               enabled: true
-            rereank:
+            rerank:
               enabled: true
             retrieval:
               enabled: true
@@ -277,6 +294,9 @@ config:
     #   prometheus:
     #     port: 6060
     #     path: /metrics
+    ## port 0 disables the health-check endpoint; set a non-zero port to enable it
+    health_check:
+      port: 0
 
 ## Env variables that will override configmap values
 ## For example:


### PR DESCRIPTION
This PR bumps OBI to v0.10.0 and:
- updates default `contextPropagation.mode` from "http,tcp" to "headers,tcp" 
- fixes typo in default config: `payload_extraction.http.genai.rerank`
- adds `runtimeMetrics.go.enabled` and `runtimeMetrics.jvm.enabled` options (both default `false`) to opt in to the new Go and JVM application runtime metrics
- adds `health_check.port` (default `0`/disabled) to the default OBI config to surface the new pipeline health-check endpoint
-  updates `stats.enabled: true` now also adds the "stats" metrics feature to `otel_metrics_export.features`; previously it only mounted tracefs, so stat probes loaded as no-op stubs and no stats metrics were ever exported
- migrates default discovery config from deprecated `services`/`exclude_services` to `instrument`/`exclude_instrument` with glob syntax
- fixes default `k8s_namespace` pattern from `.` (matches any single character) to `"*"` (glob for any namespace)