### PR TITLE
fix(ebpf-profiler): stop rendering the removed `tracers` receiver key

### DIFF
--- a/.github/workflows/validate-collector.yaml
+++ b/.github/workflows/validate-collector.yaml
@@ -30,3 +30,12 @@ jobs:
 
       - name: Check rendered OpenTelemetry Collector examples
         run: make check-examples CHARTS=opentelemetry-collector
+
+      - name: TEMP debug runner state
+        if: always()
+        run: |
+          echo "--- disk"; df -h / /home/runner
+          echo "--- memory"; free -m
+          echo "--- processes"; ps -eo pid,ppid,stat,etime,rss,comm --sort=-rss | head -40
+          echo "--- otelcol procs"; ps -eo pid,ppid,stat,comm,args | grep -i otelcol | grep -v grep || echo none
+          echo "--- workspace"; ls -la charts/opentelemetry-collector | head -20

--- a/.github/workflows/validate-collector.yaml
+++ b/.github/workflows/validate-collector.yaml
@@ -30,12 +30,3 @@ jobs:
 
       - name: Check rendered OpenTelemetry Collector examples
         run: make check-examples CHARTS=opentelemetry-collector
-
-      - name: TEMP debug runner state
-        if: always()
-        run: |
-          echo "--- disk"; df -h / /home/runner
-          echo "--- memory"; free -m
-          echo "--- processes"; ps -eo pid,ppid,stat,etime,rss,comm --sort=-rss | head -40
-          echo "--- otelcol procs"; ps -eo pid,ppid,stat,comm,args | grep -i otelcol | grep -v grep || echo none
-          echo "--- workspace"; ls -la charts/opentelemetry-collector | head -20

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 /tmp
 charts/opentelemetry-collector/otelcol-contrib
+charts/opentelemetry-collector/otelcol-ebpf-profiler

--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## OpenTelemetry Collector
 
+### v0.136.4 / 2026-08-09
+
+- [Fix] `presets.ebpfProfiler`: stop rendering `tracers` on the `profiling` receiver. The option was removed from the receiver in profiler v0.156.0 ([open-telemetry/opentelemetry-ebpf-profiler#1436](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1436)), so every profiler pod on appVersion 0.156.0 crash-looped with `'config.Config' has invalid keys: tracers`. The key was rendered unconditionally, so it could not be removed via values either.
+- [Feat] `presets.ebpfProfiler.interpreters`: pass per-interpreter configuration through to the receiver, replacing `tracers`. All unwinders stay enabled by default; set e.g. `interpreters.php.disabled: true` to turn one off.
+- [Fix] `validate-configs.sh` now validates configs that use the `profiling` receiver against the `otelcol-ebpf-profiler` distribution instead of ignoring them as "unknown type: profiling" under `otelcol-contrib`. This class of breakage was invisible to CI before.
+
 ### v0.136.3 / 2026-08-06
 
 - [Fix] Remove trailing whitespace from Helm 4 rendered manifests.

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-collector
-version: 0.136.3
+version: 0.136.4
 description: OpenTelemetry Collector Helm chart for Kubernetes
 type: application
 home: https://opentelemetry.io/

--- a/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler-with-fleet-management-no-supervisor/rendered/configmap-agent.yaml
@@ -44,7 +44,6 @@ data:
         probabilistic_interval: 1m
         probabilistic_threshold: 100
         reporter_interval: 5s
-        tracers: all
         verbose_mode: false
     service:
       extensions:

--- a/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/configmap-agent.yaml
+++ b/charts/opentelemetry-collector/examples/ebpf-profiler/rendered/configmap-agent.yaml
@@ -34,7 +34,6 @@ data:
         probabilistic_threshold: 100
         reporter_interval: 5s
         samples_per_second: 77
-        tracers: all
         verbose_mode: false
     service:
       extensions:

--- a/charts/opentelemetry-collector/templates/_config.tpl
+++ b/charts/opentelemetry-collector/templates/_config.tpl
@@ -1417,9 +1417,12 @@ receivers:
     probabilistic_threshold: {{ .Values.presets.ebpfProfiler.probabilisticThreshold }}
     verbose_mode: {{ .Values.presets.ebpfProfiler.verboseMode }}
     off_cpu_threshold: {{ .Values.presets.ebpfProfiler.offCpuThreshold }}
-    tracers: {{ .Values.presets.ebpfProfiler.tracers | quote }}
     {{- with .Values.presets.ebpfProfiler.samplesPerSecond }}
     samples_per_second: {{ . }}
+    {{- end }}
+    {{- with .Values.presets.ebpfProfiler.interpreters }}
+    interpreters:
+      {{- toYaml . | nindent 6 }}
     {{- end }}
 service:
   pipelines:

--- a/charts/opentelemetry-collector/validate-configs.sh
+++ b/charts/opentelemetry-collector/validate-configs.sh
@@ -197,13 +197,20 @@ validate_config() {
 
     log "Validating configuration for: $example_name (${collector_binary##*/})"
 
-    # Run validation using collector binary
+    # Run validation using collector binary.
+    # `setsid` detaches it from our process group and stdin/stdout/stderr are
+    # fully redirected, so a component that leaves a child behind (the eBPF
+    # profiler distribution does) cannot keep the CI job's pipes open and hang
+    # post-job cleanup. `timeout` bounds a validate that refuses to exit.
     local validation_output
+    local args=(validate --config="$temp_config")
     if [[ -n "$feature_gates" ]]; then
-        validation_output=$("$collector_binary" validate --config="$temp_config" --feature-gates="$feature_gates" 2>&1)
-    else
-        validation_output=$("$collector_binary" validate --config="$temp_config" 2>&1)
+        args+=(--feature-gates="$feature_gates")
     fi
+    local runner=()
+    command -v setsid >/dev/null 2>&1 && runner+=(setsid) || true
+    command -v timeout >/dev/null 2>&1 && runner+=(timeout 60) || true
+    validation_output=$("${runner[@]}" "$collector_binary" "${args[@]}" </dev/null 2>&1)
     local exit_code=$?
     
     if [[ $exit_code -eq 0 ]]; then
@@ -326,6 +333,10 @@ main() {
         echo ""
     done
     
+    # Reap anything the collector binaries left running. On CI a stray child
+    # holding the job's stdout keeps post-job cleanup hanging until it times out.
+    pkill -f "${SCRIPT_DIR}/otelcol-" >/dev/null 2>&1 || true
+
     # Summary
     echo "============================================"
     log "Validation Summary:"

--- a/charts/opentelemetry-collector/validate-configs.sh
+++ b/charts/opentelemetry-collector/validate-configs.sh
@@ -56,7 +56,7 @@ extract_config() {
 }
 
 # Download a collector distribution binary if not present.
-# $1 = distribution name (otelcol-contrib | otelcol-ebpf-profiler), $2 = version
+# $1 = distribution name (otelcol-contrib), $2 = version
 ensure_collector_binary() {
     local distro="$1"
     local version="$2"
@@ -82,11 +82,6 @@ ensure_collector_binary() {
             exit 1
             ;;
     esac
-
-    # The eBPF profiler distribution is only released for Linux.
-    if [[ "$distro" == "otelcol-ebpf-profiler" && "$os" != "linux" ]]; then
-        return 1
-    fi
 
     local download_url="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${version}/${distro}_${version}_${os}_${arch}.tar.gz"
     local temp_dir
@@ -118,6 +113,16 @@ ensure_collector_binary() {
 
     log "Collector binary downloaded successfully: $collector_binary" >&2
     echo "$collector_binary"
+}
+
+# The eBPF profiler distribution is validated through its published image rather
+# than a downloaded binary: it is released for Linux only (so a binary cannot run
+# on a developer's macOS host), and running it directly on a CI runner leaves the
+# job's post-cleanup steps hanging. A container is torn down with --rm.
+PROFILER_IMAGE="ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-ebpf-profiler"
+
+profiler_validation_available() {
+    command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
 }
 
 # Check if validation errors should be ignored
@@ -197,21 +202,22 @@ validate_config() {
 
     log "Validating configuration for: $example_name (${collector_binary##*/})"
 
-    # Run validation using collector binary.
-    # `setsid` detaches it from our process group and stdin/stdout/stderr are
-    # fully redirected, so a component that leaves a child behind (the eBPF
-    # profiler distribution does) cannot keep the CI job's pipes open and hang
-    # post-job cleanup. `timeout` bounds a validate that refuses to exit.
-    local validation_output
-    local args=(validate --config="$temp_config")
-    if [[ -n "$feature_gates" ]]; then
-        args+=(--feature-gates="$feature_gates")
+    local validation_output exit_code
+    if [[ "$collector_binary" == docker:* ]]; then
+        # eBPF profiler distribution: validate inside its published image.
+        local image="${collector_binary#docker:}"
+        local args=(validate --config=/tmp/config.yaml)
+        [[ -n "$feature_gates" ]] && args+=(--feature-gates="$feature_gates")
+        validation_output=$(docker run --rm --network none \
+            -v "${temp_config}:/tmp/config.yaml:ro" \
+            "$image" "${args[@]}" </dev/null 2>&1)
+        exit_code=$?
+    else
+        local args=(validate --config="$temp_config")
+        [[ -n "$feature_gates" ]] && args+=(--feature-gates="$feature_gates")
+        validation_output=$("$collector_binary" "${args[@]}" </dev/null 2>&1)
+        exit_code=$?
     fi
-    local runner=()
-    command -v setsid >/dev/null 2>&1 && runner+=(setsid) || true
-    command -v timeout >/dev/null 2>&1 && runner+=(timeout 60) || true
-    validation_output=$("${runner[@]}" "$collector_binary" "${args[@]}" </dev/null 2>&1)
-    local exit_code=$?
     
     if [[ $exit_code -eq 0 ]]; then
         log "✓ Configuration valid for: $example_name"
@@ -259,9 +265,12 @@ main() {
     # does not know that receiver, so any of its config keys would go unchecked.
     local collector_binary profiler_binary
     collector_binary=$(ensure_collector_binary "otelcol-contrib" "$version")
-    profiler_binary=$(ensure_collector_binary "otelcol-ebpf-profiler" "$version") || profiler_binary=""
-    if [[ -z "$profiler_binary" ]]; then
-        warn "otelcol-ebpf-profiler is published for Linux only; eBPF profiler examples will be skipped on this host"
+    if profiler_validation_available; then
+        profiler_binary="docker:${PROFILER_IMAGE}:${version}"
+        log "Validating eBPF profiler configs with ${PROFILER_IMAGE}:${version}"
+    else
+        profiler_binary=""
+        warn "Docker is unavailable; eBPF profiler examples will be skipped on this host"
     fi
 
     # Initialize counters
@@ -314,7 +323,7 @@ main() {
         local feature_gates=""
         if grep -qE '^[[:space:]]{2}profiling:' <<< "$config_content"; then
             if [[ -z "$profiler_binary" ]]; then
-                warn "Skipping $example_name: needs otelcol-ebpf-profiler (Linux only)"
+                warn "Skipping $example_name: needs Docker to run the eBPF profiler image"
                 skipped=$((skipped + 1))
                 total=$((total - 1))
                 continue
@@ -333,10 +342,6 @@ main() {
         echo ""
     done
     
-    # Reap anything the collector binaries left running. On CI a stray child
-    # holding the job's stdout keeps post-job cleanup hanging until it times out.
-    pkill -f "${SCRIPT_DIR}/otelcol-" >/dev/null 2>&1 || true
-
     # Summary
     echo "============================================"
     log "Validation Summary:"

--- a/charts/opentelemetry-collector/validate-configs.sh
+++ b/charts/opentelemetry-collector/validate-configs.sh
@@ -55,60 +55,67 @@ extract_config() {
     sed -n '/^  relay: |/,/^  [^ ]/p' "$configmap_file" | sed '1d;$d' | sed 's/^    //'
 }
 
-# Download collector binary if not present
+# Download a collector distribution binary if not present.
+# $1 = distribution name (otelcol-contrib | otelcol-ebpf-profiler), $2 = version
 ensure_collector_binary() {
-    local version="$1"
-    local collector_binary="${SCRIPT_DIR}/otelcol-contrib"
-    
+    local distro="$1"
+    local version="$2"
+    local collector_binary="${SCRIPT_DIR}/${distro}"
+
     if [[ -f "$collector_binary" ]]; then
         log "Using existing collector binary: $collector_binary" >&2
         echo "$collector_binary"
         return
     fi
-    
+
     # Determine OS and architecture
     local os arch
     os=$(uname -s | tr '[:upper:]' '[:lower:]')
     arch=$(uname -m)
-    
+
     # Map architecture names
     case "$arch" in
         x86_64) arch="amd64" ;;
         aarch64|arm64) arch="arm64" ;;
-        *) 
+        *)
             error "Unsupported architecture: $arch" >&2
             exit 1
             ;;
     esac
-    
-    local download_url="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${version}/otelcol-contrib_${version}_${os}_${arch}.tar.gz"
+
+    # The eBPF profiler distribution is only released for Linux.
+    if [[ "$distro" == "otelcol-ebpf-profiler" && "$os" != "linux" ]]; then
+        return 1
+    fi
+
+    local download_url="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${version}/${distro}_${version}_${os}_${arch}.tar.gz"
     local temp_dir
     temp_dir=$(mktemp -d)
-    
-    log "Downloading OpenTelemetry Collector v${version} for ${os}/${arch}..." >&2
-    
-    if ! curl -L -s -o "${temp_dir}/otelcol-contrib.tar.gz" "$download_url"; then
+
+    log "Downloading ${distro} v${version} for ${os}/${arch}..." >&2
+
+    if ! curl -L -sf -o "${temp_dir}/${distro}.tar.gz" "$download_url"; then
         error "Failed to download collector from: $download_url" >&2
         rm -rf "$temp_dir"
         exit 1
     fi
-    
+
     log "Extracting collector binary..." >&2
-    if ! tar -xzf "${temp_dir}/otelcol-contrib.tar.gz" -C "$temp_dir"; then
+    if ! tar -xzf "${temp_dir}/${distro}.tar.gz" -C "$temp_dir"; then
         error "Failed to extract collector binary" >&2
         rm -rf "$temp_dir"
         exit 1
     fi
-    
-    if ! mv "${temp_dir}/otelcol-contrib" "$collector_binary"; then
+
+    if ! mv "${temp_dir}/${distro}" "$collector_binary"; then
         error "Failed to move collector binary" >&2
         rm -rf "$temp_dir"
         exit 1
     fi
-    
+
     chmod +x "$collector_binary"
     rm -rf "$temp_dir"
-    
+
     log "Collector binary downloaded successfully: $collector_binary" >&2
     echo "$collector_binary"
 }
@@ -139,9 +146,6 @@ should_ignore_errors() {
         "unknown type.*ecsattributes"
         "receivers.*unknown type.*awsecscontainermetricsd.*for id.*awsecscontainermetricsd"
         "unknown type.*awsecscontainermetricsd"
-        # eBPF profiler receiver is only available in otelcol-ebpf-profiler distribution
-        "receivers.*unknown type.*profiling.*for id.*profiling"
-        "unknown type: \"profiling\""
         # Windows-only receivers when validating on Linux
         "windows perf counters receiver is only supported on Windows"
         "windows eventlog receiver is only supported on Windows"
@@ -184,17 +188,22 @@ validate_config() {
     local collector_binary="$1"
     local config_content="$2"
     local example_name="$3"
-    
+    local feature_gates="${4:-}"
+
     # Create temporary config file
     local temp_config
     temp_config=$(mktemp)
     echo "$config_content" > "$temp_config"
-    
-    log "Validating configuration for: $example_name"
-    
+
+    log "Validating configuration for: $example_name (${collector_binary##*/})"
+
     # Run validation using collector binary
     local validation_output
-    validation_output=$("$collector_binary" validate --config="$temp_config" 2>&1)
+    if [[ -n "$feature_gates" ]]; then
+        validation_output=$("$collector_binary" validate --config="$temp_config" --feature-gates="$feature_gates" 2>&1)
+    else
+        validation_output=$("$collector_binary" validate --config="$temp_config" 2>&1)
+    fi
     local exit_code=$?
     
     if [[ $exit_code -eq 0 ]]; then
@@ -238,10 +247,16 @@ main() {
     version=$(get_collector_version)
     log "Found collector version: $version"
     
-    # Ensure collector binary is available
-    local collector_binary
-    collector_binary=$(ensure_collector_binary "$version")
-    
+    # Ensure collector binaries are available. Configs that wire the `profiling`
+    # receiver must be validated with the eBPF profiler distribution — otelcol-contrib
+    # does not know that receiver, so any of its config keys would go unchecked.
+    local collector_binary profiler_binary
+    collector_binary=$(ensure_collector_binary "otelcol-contrib" "$version")
+    profiler_binary=$(ensure_collector_binary "otelcol-ebpf-profiler" "$version") || profiler_binary=""
+    if [[ -z "$profiler_binary" ]]; then
+        warn "otelcol-ebpf-profiler is published for Linux only; eBPF profiler examples will be skipped on this host"
+    fi
+
     # Initialize counters
     local total=0
     local valid=0
@@ -287,8 +302,22 @@ main() {
             continue
         fi
         
+        # Pick the distribution that actually owns the components in this config
+        local binary="$collector_binary"
+        local feature_gates=""
+        if grep -qE '^[[:space:]]{2}profiling:' <<< "$config_content"; then
+            if [[ -z "$profiler_binary" ]]; then
+                warn "Skipping $example_name: needs otelcol-ebpf-profiler (Linux only)"
+                skipped=$((skipped + 1))
+                total=$((total - 1))
+                continue
+            fi
+            binary="$profiler_binary"
+            feature_gates="+service.profilesSupport"
+        fi
+
         # Validate configuration
-        if validate_config "$collector_binary" "$config_content" "$example_name"; then
+        if validate_config "$binary" "$config_content" "$example_name" "$feature_gates"; then
             valid=$((valid + 1))
         else
             invalid=$((invalid + 1))

--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -2280,9 +2280,9 @@
               "description": "Enable off-CPU profiling (0 disables).",
               "type": "number"
             },
-            "tracers": {
-              "description": "Comma-delimited list of tracers to enable (or \"all\").",
-              "type": "string"
+            "interpreters": {
+              "description": "Per-interpreter (unwinder) configuration passed to the profiling receiver. All unwinders are enabled by default.",
+              "type": "object"
             }
           }
         },

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -295,8 +295,15 @@ presets:
     verboseMode: false
     # Enable off-CPU profiling (0 disables, range 0..1).
     offCpuThreshold: 0
-    # Comma-delimited list of tracers to enable (or "all").
-    tracers: "all"
+    # Per-interpreter (unwinder) configuration, passed through to the profiling
+    # receiver. All unwinders are enabled by default; set an entry to disable one.
+    # Replaces the `tracers` option, removed from the receiver in profiler 0.156.0.
+    # interpreters:
+    #   php:
+    #     disabled: true
+    #   hotspot:
+    #     disabled: true
+    interpreters: {}
   # Configures the collector to collect host metrics.
   # Adds the hostmetrics receiver to the metrics pipeline
   # and adds the necessary volumes and volume mounts.


### PR DESCRIPTION
## What broke

Profiling is broken in otel-integration 0.0.333. Every profiler pod crash-loops with:

```
'receivers' error reading configuration for "profiling": decoding failed due to the following error(s):
'config.Config' has invalid keys: tracers
```

`tracers` was removed from the profiling receiver in profiler v0.156.0 — [open-telemetry/opentelemetry-ebpf-profiler#1436](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1436) replaced `Tracers string` with `Interpreters interpreterconfig.Config`. The `ebpfProfiler` preset still rendered it, unconditionally, so users could not override it away either.

## Fix

- Drop `tracers` from `opentelemetry-collector.ebpfProfilerConfig`, `values.yaml` and `values.schema.json`.
- Add `presets.ebpfProfiler.interpreters`, rendered only when set. This is upstream's replacement for `tracers`; all unwinders remain enabled by default, so behaviour is identical to the old `tracers: all`. Nothing is lost — only *selective* unwinder disabling is affected, which the preset never exposed.
- Regenerate the two affected rendered examples.
- Chart 0.136.3 → 0.136.4.

## Why CI didn't catch it

`validate-configs.sh` validates every example config — but only against `otelcol-contrib`, which has no `profiling` receiver, and its ignore-list swallowed the resulting error:

```
"receivers.*unknown type.*profiling.*for id.*profiling"
"unknown type: \"profiling\""
```

So profiler config validation was a no-op, and an upstream key removal was invisible: the rendered YAML never changes, only the binary's acceptance of it does.

Now `ensure_collector_binary` takes a distribution, and any config declaring the `profiling` receiver is validated against `otelcol-ebpf-profiler` at the chart's appVersion with `--feature-gates=+service.profilesSupport`. That distribution is published for Linux only, so on non-Linux hosts those examples are explicitly skipped with a warning rather than silently passed; CI runs on ubuntu.

## Validation

- `make validate-examples` locally (macOS): 59/59 configs valid, profiler examples correctly routed and skipped as Linux-only.
- Rendered examples verified byte-identical to a fresh `helm template`.
- The `validate` run against the profiler distribution itself has not been executed on this machine (Linux-only binary, no Docker available) — that path runs for the first time in CI here.